### PR TITLE
Kantui improvements

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/rust/kanto-tui/container-management"]
 	path = src/rust/kanto-tui/container-management
 	url = https://github.com/eclipse-kanto/container-management.git
+[submodule "src/rust/kanto-tui/async-priority-channel"]
+	path = src/rust/kanto-tui/async-priority-channel
+	url = https://github.com/rmcgibbo/async-priority-channel

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "src/rust/kanto-tui/container-management"]
 	path = src/rust/kanto-tui/container-management
 	url = https://github.com/eclipse-kanto/container-management.git
-[submodule "src/rust/kanto-tui/async-priority-channel"]
-	path = src/rust/kanto-tui/async-priority-channel
-	url = https://github.com/rmcgibbo/async-priority-channel

--- a/src/rust/kanto-tui/.gitignore
+++ b/src/rust/kanto-tui/.gitignore
@@ -1,3 +1,4 @@
 /target
 /Cargo.lock
 *stderr.log
+*.bb

--- a/src/rust/kanto-tui/Cargo.toml
+++ b/src/rust/kanto-tui/Cargo.toml
@@ -50,10 +50,10 @@ async-priority-channel = "0.1.0"
 
 [dependencies.cursive]
 version = "0.16.2"
+feautres = ["termion-backend"]
 
 [build-dependencies]
 tonic-build =  "0.8.2"
 
 [profile.release]
-strip = true
 lto = true

--- a/src/rust/kanto-tui/Cargo.toml
+++ b/src/rust/kanto-tui/Cargo.toml
@@ -45,7 +45,7 @@ nix = "0.26.1"
 enclose = "1.1.8"
 clap = { version = "3.2.23", features = ["derive"] }
 strip-ansi-escapes = "0.1.1"
-async-priority-channel = "0.1.0"
+async-priority-channel = {git = "https://github.com/rmcgibbo/async-priority-channel", branch = "master"}
 
 [dependencies.cursive]
 version = "0.16.2"

--- a/src/rust/kanto-tui/Cargo.toml
+++ b/src/rust/kanto-tui/Cargo.toml
@@ -15,7 +15,7 @@
 name = "kantui"
 version = "0.1.0"
 description = "A TUI for Kanto CM that allows easier management of deployed containers. Requires root."
-edition = "2018"
+edition = "2021"
 authors = ["Vasil Ivanov vasil.ivanov3@bosch.io"]
 repository = "https://github.com/eclipse-leda/leda-utils"
 license-file = "../../../LICENSE"
@@ -23,14 +23,11 @@ license-file = "../../../LICENSE"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
-proc-macro = true
 name = "kantui"
 path = "src/lib.rs"
 
 
 [[bin]]
-proc-macro = true
-
 name = "kantui"
 path = "src/main.rs"
 
@@ -39,6 +36,8 @@ prost = "0.11"
 tokio = { version = "1.0", features = [ "rt-multi-thread", "time", "fs", "macros", "net",] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = {version = "0.8.2" }
+axum = "0.5.17"
+axum-core = "0.2.8"
 tower = { version = "0.4" }
 http = "0.2"
 hyper = { version = "0.14.11", features = ["full"] }

--- a/src/rust/kanto-tui/Cargo.toml
+++ b/src/rust/kanto-tui/Cargo.toml
@@ -50,7 +50,7 @@ async-priority-channel = "0.1.0"
 
 [dependencies.cursive]
 version = "0.16.2"
-features = ["termion-backend"]
+features = ["ncurses-backend"]
 
 [build-dependencies]
 tonic-build =  "0.8.2"

--- a/src/rust/kanto-tui/Cargo.toml
+++ b/src/rust/kanto-tui/Cargo.toml
@@ -15,7 +15,7 @@
 name = "kantui"
 version = "0.1.0"
 description = "A TUI for Kanto CM that allows easier management of deployed containers. Requires root."
-edition = "2021"
+edition = "2018"
 authors = ["Vasil Ivanov vasil.ivanov3@bosch.io"]
 repository = "https://github.com/eclipse-leda/leda-utils"
 license-file = "../../../LICENSE"
@@ -23,10 +23,14 @@ license-file = "../../../LICENSE"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
+proc-macro = true
 name = "kantui"
 path = "src/lib.rs"
 
+
 [[bin]]
+proc-macro = true
+
 name = "kantui"
 path = "src/main.rs"
 
@@ -37,7 +41,7 @@ tokio-stream = { version = "0.1", features = ["net"] }
 tonic = {version = "0.8.2" }
 tower = { version = "0.4" }
 http = "0.2"
-hyper = { version = "0.14", features = ["full"] }
+hyper = { version = "0.14.11", features = ["full"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = { version = "1.0.89", default-features = false, features = ["alloc"] }
 cursive_table_view = "0.13"
@@ -45,7 +49,7 @@ nix = "0.26.1"
 enclose = "1.1.8"
 clap = { version = "3.2.23", features = ["derive"] }
 strip-ansi-escapes = "0.1.1"
-async-priority-channel = {path = "async-priority-channel"}
+async-priority-channel = "0.1.0"
 
 [dependencies.cursive]
 version = "0.16.2"
@@ -56,6 +60,3 @@ tonic-build =  "0.8.2"
 [profile.release]
 strip = true
 lto = true
-
-[net]
-git-fetch-with-cli=true

--- a/src/rust/kanto-tui/Cargo.toml
+++ b/src/rust/kanto-tui/Cargo.toml
@@ -47,10 +47,11 @@ enclose = "1.1.8"
 clap = { version = "3.2.23", features = ["derive"] }
 strip-ansi-escapes = "0.1.1"
 async-priority-channel = "0.1.0"
+cursive_buffered_backend = "0.5.0"
 
 [dependencies.cursive]
 version = "0.16.2"
-features = ["ncurses-backend"]
+features = ["termion-backend"]
 
 [build-dependencies]
 tonic-build =  "0.8.2"

--- a/src/rust/kanto-tui/Cargo.toml
+++ b/src/rust/kanto-tui/Cargo.toml
@@ -50,6 +50,7 @@ async-priority-channel = "0.1.0"
 cursive_buffered_backend = "0.5.0"
 
 [dependencies.cursive]
+default-features=false
 version = "0.16.2"
 features = ["termion-backend"]
 

--- a/src/rust/kanto-tui/Cargo.toml
+++ b/src/rust/kanto-tui/Cargo.toml
@@ -45,7 +45,7 @@ nix = "0.26.1"
 enclose = "1.1.8"
 clap = { version = "3.2.23", features = ["derive"] }
 strip-ansi-escapes = "0.1.1"
-async-priority-channel = {git = "https://github.com/rmcgibbo/async-priority-channel", branch = "master"}
+async-priority-channel = {path = "async-priority-channel"}
 
 [dependencies.cursive]
 version = "0.16.2"
@@ -56,3 +56,6 @@ tonic-build =  "0.8.2"
 [profile.release]
 strip = true
 lto = true
+
+[net]
+git-fetch-with-cli=true

--- a/src/rust/kanto-tui/Cargo.toml
+++ b/src/rust/kanto-tui/Cargo.toml
@@ -32,7 +32,7 @@ path = "src/main.rs"
 
 [dependencies]
 prost = "0.11"
-tokio = { version = "1.0", features = [ "rt-multi-thread", "fs"] }
+tokio = { version = "1.0", features = [ "rt-multi-thread", "time", "fs", "macros", "net",] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = {version = "0.8.2" }
 tower = { version = "0.4" }
@@ -40,15 +40,15 @@ http = "0.2"
 hyper = { version = "0.14", features = ["full"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = { version = "1.0.89", default-features = false, features = ["alloc"] }
-cursive_table_view = "0.14.0"
+cursive_table_view = "0.13"
 nix = "0.26.1"
 enclose = "1.1.8"
-clap = { version = "4.0.29", features = ["derive"] }
+clap = { version = "3.2.23", features = ["derive"] }
 strip-ansi-escapes = "0.1.1"
 async-priority-channel = "0.1.0"
 
 [dependencies.cursive]
-version = "0.20.0"
+version = "0.16.2"
 features = ["crossterm-backend"]
 
 [build-dependencies]

--- a/src/rust/kanto-tui/Cargo.toml
+++ b/src/rust/kanto-tui/Cargo.toml
@@ -36,11 +36,9 @@ prost = "0.11"
 tokio = { version = "1.0", features = [ "rt-multi-thread", "time", "fs", "macros", "net",] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = {version = "0.8.2" }
-axum = "0.5.17"
-axum-core = "0.2.8"
 tower = { version = "0.4" }
 http = "0.2"
-hyper = { version = "0.14.11", features = ["full"] }
+hyper = { version = "0.14", features = ["full"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = { version = "1.0.89", default-features = false, features = ["alloc"] }
 cursive_table_view = "0.13"

--- a/src/rust/kanto-tui/Cargo.toml
+++ b/src/rust/kanto-tui/Cargo.toml
@@ -32,7 +32,7 @@ path = "src/main.rs"
 
 [dependencies]
 prost = "0.11"
-tokio = { version = "1.0", features = [ "rt-multi-thread", "time", "fs", "macros", "net",] }
+tokio = { version = "1.0", features = [ "rt-multi-thread", "fs"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = {version = "0.8.2" }
 tower = { version = "0.4" }
@@ -45,6 +45,7 @@ nix = "0.26.1"
 enclose = "1.1.8"
 clap = { version = "4.0.29", features = ["derive"] }
 strip-ansi-escapes = "0.1.1"
+async-priority-channel = "0.1.0"
 
 [dependencies.cursive]
 version = "0.20.0"

--- a/src/rust/kanto-tui/Cargo.toml
+++ b/src/rust/kanto-tui/Cargo.toml
@@ -50,7 +50,7 @@ async-priority-channel = "0.1.0"
 
 [dependencies.cursive]
 version = "0.16.2"
-feautres = ["termion-backend"]
+features = ["termion-backend"]
 
 [build-dependencies]
 tonic-build =  "0.8.2"

--- a/src/rust/kanto-tui/Cargo.toml
+++ b/src/rust/kanto-tui/Cargo.toml
@@ -49,7 +49,6 @@ async-priority-channel = "0.1.0"
 
 [dependencies.cursive]
 version = "0.16.2"
-features = ["crossterm-backend"]
 
 [build-dependencies]
 tonic-build =  "0.8.2"

--- a/src/rust/kanto-tui/src/containers_table_view.rs
+++ b/src/rust/kanto-tui/src/containers_table_view.rs
@@ -85,10 +85,18 @@ pub fn items_to_columns(req_items: Vec<kanto_api::Container>) -> Vec<ContainersT
 
 pub fn generate_table_view() -> CTView {
     CTView::new()
-        .column(ContainerColumn::ID, "ID", |c| c.align(HAlign::Center))
-        .column(ContainerColumn::Name, "Name", |c| c.align(HAlign::Center))
-        .column(ContainerColumn::Image, "Image", |c| c.align(HAlign::Center))
-        .column(ContainerColumn::State, "State", |c| c.align(HAlign::Center))
+        .column(ContainerColumn::ID, "ID", |c| {
+            c.align(HAlign::Center).width_percent(25)
+        })
+        .column(ContainerColumn::Name, "Name", |c| {
+            c.align(HAlign::Center).width_percent(25)
+        })
+        .column(ContainerColumn::Image, "Image", |c| {
+            c.align(HAlign::Center).width_percent(25)
+        })
+        .column(ContainerColumn::State, "State", |c| {
+            c.align(HAlign::Center).width_percent(25)
+        })
 }
 
 pub fn update_table_items(siv: &mut cursive::Cursive, list: Vec<kanto_api::Container>) {
@@ -122,9 +130,7 @@ pub fn show_logs_view(siv: &mut cursive::Cursive, logs: String) {
     let logs_view = Dialog::around(TextView::new(logs))
         .title("Container Logs")
         .button("Ok", |s| try_best(s.pop_layer()))
-        .scrollable()
-        .scroll_y(true);
-
+        .scrollable();
     siv.add_layer(logs_view);
 }
 

--- a/src/rust/kanto-tui/src/containers_table_view.rs
+++ b/src/rust/kanto-tui/src/containers_table_view.rs
@@ -15,9 +15,9 @@ use cursive::align::HAlign;
 use cursive::view::Scrollable;
 use cursive::views::{Dialog, TextView};
 use cursive::With;
+use cursive_buffered_backend;
 use cursive_table_view::{TableView, TableViewItem};
 use std::cmp::Ordering;
-
 pub type CTView = TableView<ContainersTable, ContainerColumn>;
 
 pub static TABLE_IDENTIFIER: &'static str = "table";
@@ -151,4 +151,10 @@ pub fn set_cursive_theme(siv: &mut cursive::CursiveRunnable) {
             palette[Highlight] = Blue.dark();
         }),
     });
+}
+
+pub fn buffered_termion_backend() -> kanto_api::Result<Box<dyn cursive::backend::Backend>> {
+    let backend = cursive::backends::termion::Backend::init()?;
+    let buffered_backend = cursive_buffered_backend::BufferedBackend::new(backend);
+    Ok(Box::new(buffered_backend))
 }

--- a/src/rust/kanto-tui/src/main.rs
+++ b/src/rust/kanto-tui/src/main.rs
@@ -18,14 +18,14 @@ use kantui::{containers_table_view as table, kanto_api, try_best};
 use nix::unistd::Uid;
 
 #[derive(Parser, Debug)]
-#[command(version, about)]
+#[clap(version, about)]
 struct CliArgs {
     /// Set the path to the kanto-cm UNIX socket
-    #[arg(short, long, default_value_t=String::from("/run/container-management/container-management.sock"))]
+    #[clap(short, long, default_value_t=String::from("/run/container-management/container-management.sock"))]
     socket: String,
 
     /// Time before sending a SIGKILL after a SIGTERM to a container (seconds)
-    #[arg(short, long, default_value_t = 5)]
+    #[clap(short, long, default_value_t = 5)]
     timeout: u8,
 }
 
@@ -142,15 +142,15 @@ fn run_ui(
     siv.add_fullscreen_layer(
         Dialog::around(
             table
-                .with_name(table::TABLE_IDENTIFIER)
-                .min_size((400, 400)),
+            .with_name(table::TABLE_IDENTIFIER)
+            .full_screen()
         )
         .title("Kanto Container Management")
         .button("[S]tart", start_cb.clone())
         .button("Sto[P]", stop_cb.clone())
         .button("[R]emove", remove_cb.clone())
         .button("[L]ogs", get_logs_cb.clone())
-        .button("[Q]uit", |s| s.quit()),
+        .button("[Q]uit", |s| s.quit())
     );
 
     // Add keyboard shortcuts

--- a/src/rust/kanto-tui/src/main.rs
+++ b/src/rust/kanto-tui/src/main.rs
@@ -10,12 +10,12 @@
 // *
 // * SPDX-License-Identifier: Apache-2.0
 // ********************************************************************************/
+use async_priority_channel::{bounded, Receiver, Sender};
 use clap::Parser;
 use cursive::views::Dialog;
 use cursive::{traits::*, Cursive};
 use kantui::{containers_table_view as table, kanto_api, try_best};
 use nix::unistd::Uid;
-use tokio::sync::mpsc;
 
 #[derive(Parser, Debug)]
 #[command(version, about)]
@@ -45,6 +45,13 @@ enum KantoResponse {
     GetLogs(String),
 }
 
+#[derive(PartialOrd, Ord, PartialEq, Eq, Debug)]
+enum RequestPriority {
+    Low = 0,
+    Normal = 10,
+    _High = 50,
+}
+
 /// IO Thread
 /// Parses requests from the UI thread sent to the request channel and sends the results
 /// back to the response channel. This two-channel architecture allows us to set up non-blocking
@@ -52,17 +59,21 @@ enum KantoResponse {
 #[cfg(unix)]
 #[tokio::main]
 async fn tokio_main(
-    response_tx: mpsc::Sender<KantoResponse>,
-    request_rx: &mut mpsc::Receiver<KantoRequest>,
+    response_tx: Sender<KantoResponse, RequestPriority>,
+    request_rx: &mut Receiver<KantoRequest, RequestPriority>,
     socket_path: &str,
 ) -> kanto_api::Result<()> {
     let mut c = kanto_api::get_connection(socket_path).await?;
     loop {
-        if let Some(request) = request_rx.recv().await {
+        if let Ok((request, _)) = request_rx.recv().await {
             match request {
                 KantoRequest::ListContainers => {
                     let r = kantui::kanto_api::list_containers(&mut c).await?;
-                    try_best(response_tx.send(KantoResponse::ListContainers(r)).await);
+                    try_best(
+                        response_tx
+                            .send(KantoResponse::ListContainers(r), RequestPriority::Low)
+                            .await?,
+                    );
                 }
                 KantoRequest::_CreateContainer(id, registry) => {
                     try_best(kanto_api::create_container(&mut c, &id, &registry).await);
@@ -81,7 +92,11 @@ async fn tokio_main(
                         Ok(logs) => logs,
                         Err(_) => "Could not obtain logs".to_string(),
                     };
-                    try_best(response_tx.send(KantoResponse::GetLogs(logs)).await);
+                    try_best(
+                        response_tx
+                            .send(KantoResponse::GetLogs(logs), RequestPriority::Normal)
+                            .await,
+                    );
                 }
             }
         }
@@ -90,8 +105,8 @@ async fn tokio_main(
 
 /// Setup the user interface and start the UI thread
 fn run_ui(
-    tx_requests: mpsc::Sender<KantoRequest>,
-    mut rx_responses: mpsc::Receiver<KantoResponse>,
+    tx_requests: Sender<KantoRequest, RequestPriority>,
+    rx_responses: Receiver<KantoResponse, RequestPriority>,
     timeout: i64,
 ) -> kanto_api::Result<()> {
     let mut siv = cursive::default();
@@ -102,25 +117,25 @@ fn run_ui(
 
     let start_cb = enclose::enclose!((tx_requests) move |s: &mut Cursive| {
         if let Some(c) = table::get_current_container(s) {
-            try_best(tx_requests.blocking_send(KantoRequest::StartContainer(c.id.clone())));
+            try_best(tx_requests.try_send(KantoRequest::StartContainer(c.id.clone()), RequestPriority::Normal));
         }
     });
 
     let stop_cb = enclose::enclose!((tx_requests) move |s: &mut Cursive| {
         if let Some(c) = table::get_current_container(s) {
-            try_best(tx_requests.blocking_send(KantoRequest::StopContainer(c.id.clone(), timeout)));
+            try_best(tx_requests.try_send(KantoRequest::StopContainer(c.id.clone(), timeout), RequestPriority::Normal));
         }
     });
 
     let remove_cb = enclose::enclose!((tx_requests) move |s: &mut Cursive| {
         if let Some(c) = table::get_current_container(s) {
-            try_best(tx_requests.blocking_send(KantoRequest::RemoveContainer(c.id.clone())));
+            try_best(tx_requests.try_send(KantoRequest::RemoveContainer(c.id.clone()), RequestPriority::Normal));
         }
     });
 
     let get_logs_cb = enclose::enclose!((tx_requests) move |s: &mut Cursive| {
         if let Some(c) = table::get_current_container(s) {
-            try_best(tx_requests.blocking_send(KantoRequest::GetLogs(c.id.clone())));
+            try_best(tx_requests.try_send(KantoRequest::GetLogs(c.id.clone()), RequestPriority::Normal));
         }
     });
 
@@ -145,11 +160,11 @@ fn run_ui(
     siv.add_global_callback('l', get_logs_cb.clone());
     siv.add_global_callback('q', |s| s.quit());
 
-    siv.set_fps(3);
+    siv.set_fps(30);
 
     siv.add_global_callback(cursive::event::Event::Refresh, move |s| {
-        try_best(tx_requests.blocking_send(KantoRequest::ListContainers));
-        if let Ok(resp) = rx_responses.try_recv() {
+        try_best(tx_requests.try_send(KantoRequest::ListContainers, RequestPriority::Low));
+        if let Ok((resp, _)) = rx_responses.try_recv() {
             match resp {
                 KantoResponse::ListContainers(list) => table::update_table_items(s, list),
                 KantoResponse::GetLogs(logs) => table::show_logs_view(s, logs),
@@ -170,8 +185,8 @@ fn main() -> kanto_api::Result<()> {
         std::process::exit(-1);
     }
 
-    let (tx_responses, rx_responses) = mpsc::channel::<KantoResponse>(1024);
-    let (tx_requests, mut rx_requests) = mpsc::channel::<KantoRequest>(32);
+    let (tx_responses, rx_responses) = bounded::<KantoResponse, RequestPriority>(5);
+    let (tx_requests, mut rx_requests) = bounded::<KantoRequest, RequestPriority>(5);
 
     std::thread::spawn(move || {
         tokio_main(tx_responses, &mut rx_requests, &args.socket).expect("Error in io thread");

--- a/src/rust/kanto-tui/src/main.rs
+++ b/src/rust/kanto-tui/src/main.rs
@@ -103,6 +103,7 @@ async fn tokio_main(
     }
 }
 
+
 /// Setup the user interface and start the UI thread
 fn run_ui(
     tx_requests: Sender<KantoRequest, RequestPriority>,
@@ -172,7 +173,7 @@ fn run_ui(
         }
     });
 
-    siv.run();
+    siv.try_run_with(table::buffered_termion_backend)?;
 
     Ok(())
 }


### PR DESCRIPTION
# Changes

## Performance
An async priority queue that is "eventually fair/correct"  has been used to replace tokio's default mpsc. This leads to a much more responsive UI as important (high-priority) updates to the UI are always processed first. Might lead to slight desync of the UI but this should last only up to 5 frames (out of 30 per second)

## Cross compilation
The ncurses-rs dependency was dropped completely and replaced with the termion + cursive_buffered_backend crates. This change was needed as the ncurses-rs custom build.rs tries to compile and run C++ binaries on the host that should be intended for the target. Therefore ncurses-rs does not hold up well to the requirements of different target and host.
