### PR TITLE
Kanto auto deployer error handling

### DIFF
--- a/src/rust/kanto-auto-deployer/src/main.rs
+++ b/src/rust/kanto-auto-deployer/src/main.rs
@@ -27,7 +27,7 @@ use glob::glob;
 
 fn print_usage() {
     println!("USAGE:");
-    println!("  kant-auto-deployer [PATH TO MANIFESTS FOLDER]")
+    println!("  kanto-auto-deployer [PATH TO MANIFESTS FOLDER]")
 }
 
 async fn start(_client: &mut kanto::containers_client::ContainersClient<tonic::transport::Channel>, name: &String, _id: &String) -> Result<(), Box<dyn std::error::Error>> {
@@ -82,10 +82,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             print_usage();
             return Ok(());
         }
-        path.push_str(&file_path.clone())
+        path.push_str(&file_path.clone());
     } else {
         file_path.push_str(".");
-        path.push_str(&file_path.clone())
+        path.push_str(&file_path.clone());
     }
     file_path.push_str("/*.json");
 
@@ -108,11 +108,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Ok(_) => {},
             Err(e) => println!("[CM error] Failed to create container: {}", e)
         };
-        full_name.clear()
+        full_name.clear();
     }
     if !b_found {
         println!("No manifests are found in [{}]", path);
-        print_usage()
+        print_usage();
     }
     Ok(())
 }

--- a/src/rust/kanto-auto-deployer/src/main.rs
+++ b/src/rust/kanto-auto-deployer/src/main.rs
@@ -100,11 +100,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut b_found = false;
     println!("Reading manifests from [{}]", path);
     let mut full_name = String::new();
-    for entry in glob(&file_path)? {
-        let name= entry?.display().to_string();
+    for entry in glob(&file_path).expect("Failed to parse glob pattern") {
+        let name = entry.expect("Path to entry is unreadable").display().to_string();
         full_name.push_str(&name);
         b_found = true;
-        create(&mut client, &full_name).await?;
+        match create(&mut client, &full_name).await {
+            Ok(_) => {},
+            Err(e) => println!("[CM error] Failed to create container: {}", e)
+        };
         full_name.clear()
     }
     if !b_found {


### PR DESCRIPTION
The error handling in auto deployer was improved in order for the service not to crash when a container failed to create.

Also, some minor typos were fixed.