### PR TITLE
Update cloudconnector path in sdv-provision

### DIFF
--- a/src/sh/sdv-provision
+++ b/src/sh/sdv-provision
@@ -28,8 +28,8 @@ CERT_DIR="/data/var/certificates"
 DATA_AZURE_ID_SCOPE_FILE="/data/var/certificates/azure.idscope"
 DATA_AZURE_CONNECTION_STRING_FILE="/data/var/certificates/azure.connectionstring"
 
-CLOUDCONNECTOR_DEPLOYMENT_DESCRIPTOR_TEMPLATE="/data/var/containers/manifests/cloudconnector.json.template"
-CLOUDCONNECTOR_DEPLOYMENT_DESCRIPTOR="/data/var/containers/manifests/cloudconnector.json"
+CLOUDCONNECTOR_DEPLOYMENT_DESCRIPTOR_TEMPLATE="/data/var/containers/manifests_dev/cloudconnector.json.template"
+CLOUDCONNECTOR_DEPLOYMENT_DESCRIPTOR="/data/var/containers/manifests_dev/cloudconnector.json"
 
 if [ -d ${CERT_DIR} ]; then
     echo "- Certificates directory exists"


### PR DESCRIPTION
Account for the new concept of manifests and manifests_dev. After changing the path and running sdv-provision, the manifest was successfully updated:

```json
    "env": [
      "CERT_FILE=/device.crt",
      "KEY_FILE=/device.key",
      "LOCAL_ADDRESS=tcp://mosquitto:1883",
      "LOG_FILE=",
      "LOG_LEVEL=INFO",
      "CA_CERT_PATH=/app/iothub.crt",
      "MESSAGE_MAPPER_CONFIG=/app/message-mapper-config.json",
      "ALLOWED_LOCAL_TOPICS_LIST=cloudConnector/#",
      "CONNECTION_STRING=HostName=<conn-string>;DeviceId=<dev-id>"
    ],
```

And the cloudconnector is able to connect to the azure iot hub:
```text
...
 2023/02/20 14:39:51.663898  [azure-connector]  INFO   Connection status {"connected":true,"timestamp":1676903991}                                             
...
```