### PR TITLE
Build and release workflows

### DIFF
--- a/.github/workflows/build-kanto-auto-deployer.yaml
+++ b/.github/workflows/build-kanto-auto-deployer.yaml
@@ -33,6 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           submodules: 'recursive'
       - name: Install Rust
         run: rustup update stable

--- a/.github/workflows/build-kanto-auto-deployer.yaml
+++ b/.github/workflows/build-kanto-auto-deployer.yaml
@@ -44,6 +44,11 @@ jobs:
         uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            src/rust/kanto-auto-deployer/ -> target
+            src/rust/kantui/ -> target
       - name: Build binary
         run: |
           cd src/rust/kanto-auto-deployer

--- a/.github/workflows/build-kanto-auto-deployer.yaml
+++ b/.github/workflows/build-kanto-auto-deployer.yaml
@@ -104,6 +104,6 @@ jobs:
           desc: 'Automated container deployment based on JSON descriptors for Eclipse Kanto Container Management'
       - uses: actions/upload-artifact@v3
         with:
-          name: kanto-auto-deployer-${{ matrix.target }}-debian
+          name: kanto-auto-deployer-debian
           path: 
             ./*.deb

--- a/.github/workflows/build-kanto-auto-deployer.yaml
+++ b/.github/workflows/build-kanto-auto-deployer.yaml
@@ -12,7 +12,7 @@
 # ********************************************************************************/
 #
 
-name: Build KantUI
+name: Build Kanto Auto Deployer
 
 on:
   workflow_dispatch:
@@ -46,28 +46,25 @@ jobs:
           target: ${{ matrix.target }}
       - name: Build binary
         run: |
-          cd src/rust/kanto-tui
+          cd src/rust/kanto-auto-deployer
           cargo build --release
       - name: Package 
         run: |
-          cp src/rust/kanto-tui/kantui_conf.toml . 
-          cp src/rust/kanto-tui/target/${{ matrix.target }}/release/kantui . 
-          chmod +x kantui
-          strip ./kantui
-          tar czf kantui-${{ matrix.target }}.tar.gz kantui_conf.toml kantui
+          cp src/rust/kanto-auto-deployer/target/${{ matrix.target }}/release/kanto-auto-deployer . 
+          chmod +x kanto-auto-deployer
+          strip ./kanto-auto-deployer
+          tar czf kanto-auto-deployer-${{ matrix.target }}.tar.gz kanto-auto-deployer
       - name: Upload files
         uses: actions/upload-artifact@v3
         with: 
-          name: kantui-${{ matrix.target }}.tar.gz
+          name: kanto-auto-deployer-${{ matrix.target }}.tar.gz
           if-no-files-found: error
-          path: kantui-${{ matrix.target }}.tar.gz
+          path: kanto-auto-deployer-${{ matrix.target }}.tar.gz
       - name: Debian Package Preparation
         run: |
           mkdir -p .debpkg/usr/bin
-          mkdir -p .debpkg/etc/kantui
-          cp kantui_conf.toml .debpkg/etc/kantui/
-          cp kantui .debpkg/usr/bin
-          chmod +x .debpkg/usr/bin/kantui
+          cp kanto-auto-deployer .debpkg/usr/bin
+          chmod +x .debpkg/usr/bin/kanto-auto-deployer
 
           # create DEBIAN directory if you want to add other pre/post scripts
           mkdir -p .debpkg/DEBIAN
@@ -93,15 +90,15 @@ jobs:
           fi
       - uses: jiro4989/build-deb-action@v2
         with:
-          package: eclipse-leda-kantui
+          package: eclipse-leda-kanto-auto-deployer
           package_root: .debpkg
           maintainer: Eclipse Leda Development Team
           version: '${{ env.package_version }}'
           arch: '${{ env.package_arch }}'
           depends: 'libc6'
-          desc: 'Text user interface (cli) for Eclipse Kanto Container Management'
+          desc: 'Automated container deployment based on JSON descriptors for Eclipse Kanto Container Management'
       - uses: actions/upload-artifact@v3
         with:
-          name: kantui-debian-packages
+          name: kanto-auto-deployer-debian-packages
           path: 
             ./*.deb

--- a/.github/workflows/build-kanto-auto-deployer.yaml
+++ b/.github/workflows/build-kanto-auto-deployer.yaml
@@ -58,11 +58,11 @@ jobs:
         run: |
           cp src/rust/kanto-auto-deployer/target/${{ matrix.target }}/release/kanto-auto-deployer . 
           chmod +x kanto-auto-deployer
-          tar czf kanto-auto-deployer-${{ matrix.target }}.tar.gz kanto-auto-deployer
+          tar czf kanto-auto-deployer-${{ matrix.target }}.tar.gz kanto-auto-deployer LICENSE README.md NOTICE.md
       - name: Upload files
         uses: actions/upload-artifact@v3
         with: 
-          name: kanto-auto-deployer-${{ matrix.target }}.tar.gz
+          name: kanto-auto-deployer-${{ matrix.target }}-archive
           if-no-files-found: error
           path: kanto-auto-deployer-${{ matrix.target }}.tar.gz
       - name: Debian Package Preparation
@@ -104,6 +104,6 @@ jobs:
           desc: 'Automated container deployment based on JSON descriptors for Eclipse Kanto Container Management'
       - uses: actions/upload-artifact@v3
         with:
-          name: kanto-auto-deployer-debian-packages
+          name: kanto-auto-deployer-${{ matrix.target }}-debian
           path: 
             ./*.deb

--- a/.github/workflows/build-kanto-auto-deployer.yaml
+++ b/.github/workflows/build-kanto-auto-deployer.yaml
@@ -19,7 +19,7 @@ on:
   workflow_call:
 
 jobs:
-  test:
+  build:
     strategy:
       matrix:
         target:
@@ -58,7 +58,6 @@ jobs:
         run: |
           cp src/rust/kanto-auto-deployer/target/${{ matrix.target }}/release/kanto-auto-deployer . 
           chmod +x kanto-auto-deployer
-          strip ./kanto-auto-deployer
           tar czf kanto-auto-deployer-${{ matrix.target }}.tar.gz kanto-auto-deployer
       - name: Upload files
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -77,7 +77,7 @@ jobs:
           package: kantui
           package_root: .debpkg
           maintainer: Eclipse Leda Development Team
-          version: ${{ github.ref }} # refs/tags/v*.*.*
+          version: 0.2.0
           arch: '${{ env.package_arch }}'
           depends: 'libc6 (>= 2.2.1), git'
           desc: 'User interface (ncurses) for Kanto Container Management'

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -1,0 +1,57 @@
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+#
+
+name: Build KantUI
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        target:
+          - aarch64-unknown-linux-gnu
+          - x86_64-unknown-linux-gnu
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Install Rust
+        run: rustup update stable
+      - name: Install Tools
+        run: |
+          apt-get update
+          apt-get install -y protobuf-compiler
+      - name: Install cross-compilation tools
+        uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+      - name: Build binary
+        run: |
+          cd src/rust/kanto-tui
+          cargo build --release
+      - name: Package 
+        run: |
+          cp src/rust/kanto-tui/kantui_conf.toml . 
+          cp src/rust/kanto-tui/target/${{ matrix.target }}/release/kantui . 
+          tar czf kantui-${{ matrix.target }}.tar.gz kantui_conf.toml release/kantui
+      - name: Upload files
+        uses: actions/upload-artifact@v3
+        with: 
+          name: kantui-${{ matrix.target }}.tar.gz
+          if-no-files-found: error
+          path: kantui-${{ matrix.target }}.tar.gz

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -25,7 +25,11 @@ jobs:
         target:
           - aarch64-unknown-linux-gnu
           - x86_64-unknown-linux-gnu
-    runs-on: ubuntu-latest
+    
+    # Not using latest here, so that building the binaries uses an older version of glibc
+    # and then can run on newer versions.
+    runs-on: ubuntu-20.04
+
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -48,10 +48,27 @@ jobs:
         run: |
           cp src/rust/kanto-tui/kantui_conf.toml . 
           cp src/rust/kanto-tui/target/${{ matrix.target }}/release/kantui . 
-          tar czf kantui-${{ matrix.target }}.tar.gz kantui_conf.toml release/kantui
+          chmod +x kantui
+          tar czf kantui-${{ matrix.target }}.tar.gz kantui_conf.toml kantui
       - name: Upload files
         uses: actions/upload-artifact@v3
         with: 
           name: kantui-${{ matrix.target }}.tar.gz
           if-no-files-found: error
           path: kantui-${{ matrix.target }}.tar.gz
+      - name: Debian Package Preparation
+        run: |
+          mkdir -p .debpkg/usr/bin
+          mkdir -p .debpkg/etc/kantui
+          cp kantui_conf.toml .debpkg/etc/kantui/
+          cp kantui .debpkg/usr/bin
+          chmod +x .debpkg/usr/bin/kantui
+      - uses: jiro4989/build-deb-action@v2
+        with:
+          package: kantui
+          package_root: .debpkg
+          maintainer: Eclipse Leda Development Team
+          version: ${{ github.ref }} # refs/tags/v*.*.*
+          arch: 'amd64'
+          depends: 'libc6 (>= 2.2.1), git'
+          desc: 'User interface (ncurses) for Kanto Container Management'

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -19,7 +19,7 @@ on:
   workflow_call:
 
 jobs:
-  test:
+  build:
     strategy:
       matrix:
         target:
@@ -59,7 +59,6 @@ jobs:
           cp src/rust/kanto-tui/kantui_conf.toml . 
           cp src/rust/kanto-tui/target/${{ matrix.target }}/release/kantui . 
           chmod +x kantui
-          strip ./kantui
           tar czf kantui-${{ matrix.target }}.tar.gz kantui_conf.toml kantui
       - name: Upload files
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -69,7 +69,7 @@ jobs:
           echo "package_version=`echo $(git describe --tags --always | tr -d [:alpha:])`" >> $GITHUB_ENV
           if [ "${{ matrix.target }}" == "aarch64-unknown-linux-gnu" ]; then
             echo "package_arch=arm64" >> $GITHUB_ENV
-          elif if [ "${{ matrix.target }}" == "x86_64-unknown-linux-gnu" ];
+          elif [ "${{ matrix.target }}" == "x86_64-unknown-linux-gnu" ]; then
             echo "package_arch=amd64" >> $GITHUB_ENV
           else
             echo "::error::Unknown architecture: ${{ matrix.target }}"

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -67,9 +67,21 @@ jobs:
           cp kantui_conf.toml .debpkg/etc/kantui/
           cp kantui .debpkg/usr/bin
           chmod +x .debpkg/usr/bin/kantui
+          strip ./kantui
+
+          # create DEBIAN directory if you want to add other pre/post scripts
+          mkdir -p .debpkg/DEBIAN
+          cat <<EOT > .debpkg/DEBIAN/copyright
+          Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+          Upstream-Name: Eclipse Leda
+          Source: github.com/eclipse-leda/
+          
+          Files: *
+          Copyright: 2022-2023, Contributors to the Eclipse Foundation
+          License: APL-2.0
+          EOT          
       - name: Set variables
         run: |
-          echo "GIT_TAG=`echo $(git describe --tags --always)`" >> $GITHUB_ENV
           echo "package_version=`echo $(git describe --tags --always | tr -d [:alpha:] | sed 's/-/./g')`" >> $GITHUB_ENV
           if [ "${{ matrix.target }}" == "aarch64-unknown-linux-gnu" ]; then
             echo "package_arch=arm64" >> $GITHUB_ENV
@@ -83,12 +95,12 @@ jobs:
           package: eclipse-leda-kantui
           package_root: .debpkg
           maintainer: Eclipse Leda Development Team
-          version: '${{ env.package_version }}'
+          version: '1:${{ env.package_version }}'
           arch: '${{ env.package_arch }}'
           depends: 'libc6 (>= 2.2.1)'
           desc: 'User interface (ncurses) for Kanto Container Management'
       - uses: actions/upload-artifact@v3
         with:
           name: kantui-debian-packages
-          path: |
+          path: 
             ./*.deb

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -59,11 +59,11 @@ jobs:
           cp src/rust/kanto-tui/kantui_conf.toml . 
           cp src/rust/kanto-tui/target/${{ matrix.target }}/release/kantui . 
           chmod +x kantui
-          tar czf kantui-${{ matrix.target }}.tar.gz kantui_conf.toml kantui
+          tar czf kantui-${{ matrix.target }}.tar.gz kantui_conf.toml kantui LICENSE README.md NOTICE.md
       - name: Upload files
         uses: actions/upload-artifact@v3
         with: 
-          name: kantui-${{ matrix.target }}.tar.gz
+          name: kantui-${{ matrix.target }}-archive
           if-no-files-found: error
           path: kantui-${{ matrix.target }}.tar.gz
       - name: Debian Package Preparation
@@ -107,6 +107,6 @@ jobs:
           desc: 'Text user interface (cli) for Eclipse Kanto Container Management'
       - uses: actions/upload-artifact@v3
         with:
-          name: kantui-debian-packages
+          name: kantui-${{ matrix.target }}-debian
           path: 
             ./*.deb

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -82,7 +82,8 @@ jobs:
           EOT          
       - name: Set variables
         run: |
-          echo "package_version=`echo $(git describe --tags --always | tr -d [:alpha:] | sed 's/-/./g')`" >> $GITHUB_ENV
+          git describe --tags --always --long
+          echo "package_version=`echo $(git describe --tags --always --long | tr -d [:alpha:] | sed 's/-/./g')`" >> $GITHUB_ENV
           if [ "${{ matrix.target }}" == "aarch64-unknown-linux-gnu" ]; then
             echo "package_arch=arm64" >> $GITHUB_ENV
           elif [ "${{ matrix.target }}" == "x86_64-unknown-linux-gnu" ]; then
@@ -95,10 +96,10 @@ jobs:
           package: eclipse-leda-kantui
           package_root: .debpkg
           maintainer: Eclipse Leda Development Team
-          version: '1:${{ env.package_version }}'
+          version: '${{ env.package_version }}'
           arch: '${{ env.package_arch }}'
-          depends: 'libc6 (>= 2.2.1)'
-          desc: 'User interface (ncurses) for Kanto Container Management'
+          depends: 'libc6'
+          desc: 'Text user interface (cli) for Eclipse Kanto Container Management'
       - uses: actions/upload-artifact@v3
         with:
           name: kantui-debian-packages

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -80,7 +80,7 @@ jobs:
           fi
       - uses: jiro4989/build-deb-action@v2
         with:
-          package: kantui
+          package: eclipse-leda-kantui
           package_root: .debpkg
           maintainer: Eclipse Leda Development Team
           version: '${{ env.package_version }}'

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -107,6 +107,6 @@ jobs:
           desc: 'Text user interface (cli) for Eclipse Kanto Container Management'
       - uses: actions/upload-artifact@v3
         with:
-          name: kantui-${{ matrix.target }}-debian
+          name: kantui-debian
           path: 
             ./*.deb

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -63,8 +63,10 @@ jobs:
           cp kantui_conf.toml .debpkg/etc/kantui/
           cp kantui .debpkg/usr/bin
           chmod +x .debpkg/usr/bin/kantui
-      - name: Set the ARCH value
+      - name: Set variables
         run: |
+          echo "GIT_TAG=`echo $(git describe --tags --always)`" >> $GITHUB_ENV
+          echo "package_version=`echo $(git describe --tags --abbrev=0 | tr -d [:alpha:])`" >> $GITHUB_ENV
           if [ "${{ matrix.target }}" == "aarch64-unknown-linux-gnu" ]; then
             echo "package_arch=arm64" >> $GITHUB_ENV
           elif if [ "${{ matrix.target }}" == "x86_64-unknown-linux-gnu" ];
@@ -77,7 +79,7 @@ jobs:
           package: kantui
           package_root: .debpkg
           maintainer: Eclipse Leda Development Team
-          version: 0.2.0
+          version: '${{ env.package_version }}'
           arch: '${{ env.package_arch }}'
           depends: 'libc6 (>= 2.2.1), git'
           desc: 'User interface (ncurses) for Kanto Container Management'

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
+          fetch-depth: 0
       - name: Install Rust
         run: rustup update stable
       - name: Install Tools

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Set variables
         run: |
           echo "GIT_TAG=`echo $(git describe --tags --always)`" >> $GITHUB_ENV
-          echo "package_version=`echo $(git describe --tags --abbrev=0 | tr -d [:alpha:])`" >> $GITHUB_ENV
+          echo "package_version=`echo $(git describe --tags --always | tr -d [:alpha:])`" >> $GITHUB_ENV
           if [ "${{ matrix.target }}" == "aarch64-unknown-linux-gnu" ]; then
             echo "package_arch=arm64" >> $GITHUB_ENV
           elif if [ "${{ matrix.target }}" == "x86_64-unknown-linux-gnu" ];

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Set variables
         run: |
           echo "GIT_TAG=`echo $(git describe --tags --always)`" >> $GITHUB_ENV
-          echo "package_version=`echo $(git describe --tags --always | tr -d [:alpha:])`" >> $GITHUB_ENV
+          echo "package_version=`echo $(git describe --tags --always | tr -d [:alpha:] | sed 's/-/./g')`" >> $GITHUB_ENV
           if [ "${{ matrix.target }}" == "aarch64-unknown-linux-gnu" ]; then
             echo "package_arch=arm64" >> $GITHUB_ENV
           elif [ "${{ matrix.target }}" == "x86_64-unknown-linux-gnu" ]; then
@@ -85,10 +85,10 @@ jobs:
           maintainer: Eclipse Leda Development Team
           version: '${{ env.package_version }}'
           arch: '${{ env.package_arch }}'
-          depends: 'libc6 (>= 2.2.1), git'
+          depends: 'libc6 (>= 2.2.1)'
           desc: 'User interface (ncurses) for Kanto Container Management'
       - uses: actions/upload-artifact@v3
         with:
-          name: artifact-deb
+          name: kantui-debian-packages
           path: |
             ./*.deb

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -63,12 +63,26 @@ jobs:
           cp kantui_conf.toml .debpkg/etc/kantui/
           cp kantui .debpkg/usr/bin
           chmod +x .debpkg/usr/bin/kantui
+      - name: Set the ARCH value
+        run: |
+          if [ "${{ matrix.target }}" == "aarch64-unknown-linux-gnu" ]; then
+            echo "package_arch=arm64" >> $GITHUB_ENV
+          elif if [ "${{ matrix.target }}" == "x86_64-unknown-linux-gnu" ];
+            echo "package_arch=amd64" >> $GITHUB_ENV
+          else
+            echo "::error::Unknown architecture: ${{ matrix.target }}"
+          fi
       - uses: jiro4989/build-deb-action@v2
         with:
           package: kantui
           package_root: .debpkg
           maintainer: Eclipse Leda Development Team
           version: ${{ github.ref }} # refs/tags/v*.*.*
-          arch: 'amd64'
+          arch: '${{ env.package_arch }}'
           depends: 'libc6 (>= 2.2.1), git'
           desc: 'User interface (ncurses) for Kanto Container Management'
+      - uses: actions/upload-artifact@v3
+        with:
+          name: artifact-deb
+          path: |
+            ./*.deb

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -34,8 +34,8 @@ jobs:
         run: rustup update stable
       - name: Install Tools
         run: |
-          apt-get update
-          apt-get install -y protobuf-compiler
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
       - name: Install cross-compilation tools
         uses: taiki-e/setup-cross-toolchain-action@v1
         with:

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -44,6 +44,11 @@ jobs:
         uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            src/rust/kanto-auto-deployer/ -> target
+            src/rust/kantui/ -> target
       - name: Build binary
         run: |
           cd src/rust/kanto-tui

--- a/.github/workflows/build-leda-utils.yaml
+++ b/.github/workflows/build-leda-utils.yaml
@@ -1,0 +1,67 @@
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+#
+
+name: Build Leda-Utils
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+          fetch-depth: 0
+      - name: Debian Package Preparation
+        run: |
+          mkdir -p .debpkg/usr/bin
+          mkdir -p .debpkg/etc/sdv
+
+          cp src/sh/* .debpkg/usr/bin
+          cp src/sh/sdv.conf .debpkg/etc/sdv
+          chmod +x .debpkg/usr/bin/*
+
+          # create DEBIAN directory if you want to add other pre/post scripts
+          mkdir -p .debpkg/DEBIAN
+          cat <<EOT > .debpkg/DEBIAN/copyright
+          Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+          Upstream-Name: Eclipse Leda
+          Source: github.com/eclipse-leda/
+          
+          Files: *
+          Copyright: 2022-2023, Contributors to the Eclipse Foundation
+          License: APL-2.0
+          EOT          
+      - name: Set variables
+        run: |
+          git describe --tags --always --long
+          echo "package_version=`echo $(git describe --tags --always --long | tr -d [:alpha:] | sed 's/-/./g')`" >> $GITHUB_ENV
+      - uses: jiro4989/build-deb-action@v2
+        with:
+          package: eclipse-leda-utils
+          package_root: .debpkg
+          maintainer: Eclipse Leda Development Team
+          version: '${{ env.package_version }}'
+          arch: 'all'
+          desc: 'Shell utilities for Eclipse Leda (Software-Defined Vehicle)'
+      - uses: actions/upload-artifact@v3
+        with:
+          name: leda-utils-debian
+          path: 
+            ./*.deb
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,34 @@
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+name: Leda-Utils Build
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-kantui:
+    name: Build KantUI
+    uses: ./.github/workflows/build-kantui.yml
+    secrets: inherit
+
+  build-kanto-auto-deployer:
+    name: Build Kanto Auto Deployer
+    uses: ./.github/workflows/build-kanto-auto-deployer.yml
+    secrets: inherit
+
+build-leda-utils:
+    name: Build Leda-Utils
+    uses: ./.github/workflows/build-leda-utils.yml
+    secrets: inherit

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
     uses: ./.github/workflows/build-kanto-auto-deployer.yaml
     secrets: inherit
 
-build-leda-utils:
+  build-leda-utils:
     name: Build Leda-Utils
     uses: ./.github/workflows/build-leda-utils.yaml
     secrets: inherit

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,8 +14,8 @@
 name: Leda-Utils Build
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+  workflow_call:
 
 jobs:
   build-kantui:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,15 +20,15 @@ on:
 jobs:
   build-kantui:
     name: Build KantUI
-    uses: ./.github/workflows/build-kantui.yml
+    uses: ./.github/workflows/build-kantui.yaml
     secrets: inherit
 
   build-kanto-auto-deployer:
     name: Build Kanto Auto Deployer
-    uses: ./.github/workflows/build-kanto-auto-deployer.yml
+    uses: ./.github/workflows/build-kanto-auto-deployer.yaml
     secrets: inherit
 
 build-leda-utils:
     name: Build Leda-Utils
-    uses: ./.github/workflows/build-leda-utils.yml
+    uses: ./.github/workflows/build-leda-utils.yaml
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ on:
 jobs:
   call-build:
     name: Build
-    uses: ./.github/workflows/build.yml
+    uses: ./.github/workflows/build.yaml
     secrets: inherit
 
   upload-assets:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,48 @@
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+name: Leda-Utils Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  call-build:
+    name: Build
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+
+  upload-assets:
+    name: Upload assets
+    runs-on: ubuntu-22.04
+    needs: [ call-build ]
+    permissions:
+      contents: write
+    steps:
+      - name: Download build artifacts
+        id: download
+        uses: actions/download-artifact@v3
+        with:
+          path: build/
+      - name: Upload assets
+        uses: softprops/action-gh-release@v1
+        with:
+          fail_on_unmatched_files: true
+          files: |
+            ${{steps.download.outputs.download-path}}/kantui-debian/eclipse-leda-kantui_*_amd64.deb
+            ${{steps.download.outputs.download-path}}/kantui-debian/eclipse-leda-kantui_*_arm64.deb
+            ${{steps.download.outputs.download-path}}/kanto-auto-deployer-debian/eclipse-leda-kanto-auto-deployer_*_amd64.deb
+            ${{steps.download.outputs.download-path}}/kanto-auto-deployer-debian/eclipse-leda-kanto-auto-deployer_*_arm64.deb
+            ${{steps.download.outputs.download-path}}/leda-utils-debian/eclipse-leda-utils*.deb
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /src/rust/kanto-auto-deployer/target
+tmp
+**/*.tar.gz


### PR DESCRIPTION
Contains GitHub workflows for building the three components:
- KantUI
- Kanto Auto Deployer
- Leda Utils (shell scripts)

The components are built as tar archive (binaries for x86_64 and aarch64) and as Debian packages (.deb)
