### PR TITLE
Kanto Ctl helper

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,7 +32,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends so
         iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev pylint3 xterm python3-subunit \ 
         mesa-common-dev zstd liblz4-tool tmux mc skopeo fdisk ruby-full jq \
         libvirt-clients libvirt-daemon-system qemu-system-x86 qemu-system-arm qemu-kvm \
-        squashfs-tools rauc python3-newt
+        squashfs-tools rauc python3-newt shellcheck
+
+RUN curl -sS https://webi.sh/shfmt | sh
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install ca-certificates \
     curl \

--- a/.github/workflows/build-leda-utils.yaml
+++ b/.github/workflows/build-leda-utils.yaml
@@ -17,6 +17,9 @@ name: Build Leda-Utils
 on:
   workflow_dispatch:
   workflow_call:
+  push:
+    paths:
+      - 'src/sh/**'
 
 jobs:
   build:
@@ -31,6 +34,12 @@ jobs:
         uses: azohra/shell-linter@latest
         with:
           path: "src/sh"
+      - name: sh-checker
+        uses: luizm/action-sh-checker@v0.7.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          sh_checker_comment: true
       - name: Debian Package Preparation
         run: |
           mkdir -p .debpkg/usr/bin

--- a/.github/workflows/build-leda-utils.yaml
+++ b/.github/workflows/build-leda-utils.yaml
@@ -27,6 +27,10 @@ jobs:
         with:
           submodules: 'recursive'
           fetch-depth: 0
+      - name: Run ShellCheck
+        uses: azohra/shell-linter@latest
+        with:
+          path: "src/sh"
       - name: Debian Package Preparation
         run: |
           mkdir -p .debpkg/usr/bin

--- a/.github/workflows/build-leda-utils.yaml
+++ b/.github/workflows/build-leda-utils.yaml
@@ -40,6 +40,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           sh_checker_comment: true
+          sh_checker_shfmt_disable: true
       - name: Debian Package Preparation
         run: |
           mkdir -p .debpkg/usr/bin

--- a/src/sh/can-forward
+++ b/src/sh/can-forward
@@ -12,7 +12,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #*******************************************************************************/
 # shellcheck disable=SC3043
-
+# shellcheck disable=SC2039
 
 HOST_VXCAN="vxcan0"
 DOCKER_VXCAN="vxcan1"
@@ -34,11 +34,6 @@ get_ctr_pid() {
 	#ctr t ps $container | grep -v PID | head -n 1 | awk '{print $1}'
 	sudo --preserve-env=CONTAINERD_ADDRESS,CONTAINERD_NAMESPACE ctr t ls | grep "$container" | awk '{print $2}'
 	return $?
-}
-
-get_k3s_pid() {
-	# FIXME: implement getting entrypoint pid from kubelet with k3s tools
-	return 1
 }
 
 print_usage() {

--- a/src/sh/sdv-ctr-exec
+++ b/src/sh/sdv-ctr-exec
@@ -4,7 +4,7 @@
 # shellcheck disable=SC2086
 # shellcheck disable=SC2034
 # shellcheck disable=SC2059
-
+# shellcheck disable=SC2039
 # /********************************************************************************
 # * Copyright (c) 2023 Contributors to the Eclipse Foundation
 # *

--- a/src/sh/sdv-device-info
+++ b/src/sh/sdv-device-info
@@ -13,7 +13,7 @@
 # ********************************************************************************/
 # shellcheck disable=SC3043
 # shellcheck disable=SC2034
-
+# shellcheck disable=SC2059
 
 # Config
 COMMAND="show"

--- a/src/sh/sdv-device-info
+++ b/src/sh/sdv-device-info
@@ -14,7 +14,7 @@
 # shellcheck disable=SC3043
 # shellcheck disable=SC2034
 # shellcheck disable=SC2059
-
+# shellcheck disable=SC2039
 # Config
 COMMAND="show"
 AUTORESTART=1

--- a/src/sh/sdv-health
+++ b/src/sh/sdv-health
@@ -4,6 +4,7 @@
 # shellcheck disable=SC2086
 # shellcheck disable=SC2034
 # shellcheck disable=SC2059
+# shellcheck disable=SC2039
 # /********************************************************************************
 # * Copyright (c) 2022 Contributors to the Eclipse Foundation
 # *
@@ -375,7 +376,7 @@ init_colors
 #########################################
 # Read Local / Global SDV configuration #
 #########################################
-
+# shellcheck source=/etc/sdv/sdv.conf
 if [ -f "$HOME/.config/sdv.conf" ]; then
 	. "$HOME/.config/sdv.conf"
 	[ "$VERBOSE" = "1" ] && echo "# Config loaded from: $HOME/.config/sdv.conf" && grep -v  '^#' $HOME/.config/sdv.conf | sort -u

--- a/src/sh/sdv-health
+++ b/src/sh/sdv-health
@@ -89,9 +89,7 @@ check_service()
 	STATUS=$($SYSTEMCTL_CMD status $service -n 0 2>&1)
 	ACTIVE=$(echo "$STATUS" | grep 'Active:' | xargs)
 
-	#echo "* $service status: $ACTIVE"
-	echo "$ACTIVE" | grep -q "active (running)\|active (listening)"
-	if [ $? -eq 0 ]; then
+	if (echo "$ACTIVE" | grep -q "active (running)\|active (listening)") then
 		printf -- "$TEXT_OK\n"
 	else
 		[ -z "$ACTIVE" ] && ACTIVE="$( $SYSTEMCTL_CMD status $service -n 0 2>&1 1>/dev/null )"
@@ -151,7 +149,7 @@ prefix()
 {
 	local prefix="$1"
 	local IFS=''
-	while read line; do
+	while read -r line; do
 		printf -- "${COL_WHITE}${prefix}${COL_NC} %s\n" "${line}"
 	done
 }

--- a/src/sh/sdv-help
+++ b/src/sh/sdv-help
@@ -1,0 +1,46 @@
+#!/bin/sh
+# shellcheck disable=SC2034
+# shellcheck disable=SC1091
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+
+printf "\033[m"
+printf "Welcome to the \033[1;35mEclipse Leda Quickstart\033[m image, where you can experiment with "
+printf "COVESA \033[1;33mVehicle Signal Specification\033[m, "
+printf "Eclipse \033[1;33mKuksa.VAL Databroker\033[m, "
+printf "Eclipse \033[1;33mVelocitas\033[m, "
+printf "Eclpse \033[1;33mKanto\033[m, "
+printf "and more automotive open source packages to come from the Eclipse Software-Defined Vehicle working group.\n"
+
+printf "\n"
+printf "\033[1;34mGeneral\033[m: "
+printf "\033[mTo check SDV services health, run \033[0;37m$ \033[1;33msdv-health\033[m\n"
+printf "Use \033[0;37m$ \033[1;33msdv-provision\033[m to generate self-signed device certificates\n"
+printf "Use \033[0;37m$ \033[1;33msdv-device-info\033[m to display current device configuration\n"
+printf "Change keyboard layout with \033[0;37m$ \033[1;33mloadkeys de\033[m\n"
+
+printf "\n"
+printf "\033[1;34mContainers\033[m: "
+printf "\033[mKanto's built-in cli tool is \033[0;37m$ \033[1;33mkanto-cm\033[m\n"
+printf "\033[mFor a UI, try \033[0;37m$ \033[1;33mkantui\033[m to start/stop and view logs\n"
+printf "Use \033[0;37m$ \033[1;33mkanto-auto-deployer\033[m to deploy containers from JSON manifests\n"
+
+printf "\n"
+printf "\033[1;34mMessaging and Vehicle Signals\033[m: "
+printf "\033[mUse \033[0;37m$ \033[1;33mdatabroker-cli\033[m to connect to Eclipse Kuksa Databroker and query vehicle signals\n"
+printf "\033[mUse \033[0;37m$ \033[1;33mmosquitto_sub -t '#' -v\033[m to monitor local MQTT messages\n"
+
+printf "\033[m\n"
+printf "Have fun! Interested in SDV? Join us at https://github.com/eclipse-leda/ or https://projects.eclipse.org/projects/automotive.leda"
+printf "\033[m\n"

--- a/src/sh/sdv-kanto-ctl
+++ b/src/sh/sdv-kanto-ctl
@@ -4,6 +4,7 @@
 # shellcheck disable=SC2086
 # shellcheck disable=SC2034
 # shellcheck disable=SC2059
+# shellcheck disable=SC2039
 # /********************************************************************************
 # * Copyright (c) 2023 Contributors to the Eclipse Foundation
 # *
@@ -47,31 +48,6 @@ init_colors() {
 	export SEPARATOR="${COL_GRAY}-----------------------------------------------------------${COL_NC}"
 }
 
-cm_get_container_id ()
-{
-	local CONT_NAME=$1
-	${KANTO_CMD} get -n $CONT_NAME 2>/dev/null | jq -r " .container_id"
-}
-
-cm_check_logging_type ()
-{
-	local CONT_ID=$1
-	${KANTO_CMD} get ${CONT_ID} | jq -r " .host_config.log_config.driver_config.type"
-}
-
-cm_get_container_logs () # get the last n (following tail syntax) lines of a container's logs by name
-{
-	local CONT_NAME=$1
-	local LOG_MAX_LINES=$2
-	CONT_ID=$(cm_get_container_id $CONT_NAME)
-	if [ $CONT_ID ]; then
-		LOGGING_TYPE=$(cm_check_logging_type $CONT_ID)
-		if [ $LOGGING_TYPE = "json-file" ]; then # according to kanto docs logging type is either "json-file" (to json.log) or "none"
-			tail -n $LOG_MAX_LINES ${KANTO_CM_HOME_DIR}/containers/${CONT_ID}/${KANTO_CM_LOG_FILE}
-		fi
-	fi
-}
-
 ######################################################
 #                        setup                       #
 ######################################################
@@ -95,10 +71,10 @@ display_help() {
 		echo "		Prints all configured container registries"
 		echo "	show-config"
 		echo "		Print the container management configuration"
-		echo "	set <key> <value>"
+		echo "	set-value <key> <value>"
 		echo "		Set a primitive configuration value. Key in JSON Dot-Notation"
-		echo "		Examples: $0 set containers.registry_configurations.MyRegistry.credentials.password foobar"
-		echo "		          $0 set things.enable true"
+		echo "		Examples: $0 set-value containers.registry_configurations.MyRegistry.credentials.password foobar"
+		echo "		          $0 set-value things.enable true"
 		echo "Options:"
 		echo "	--no-reload : Do not reload the configuration and restart the container-management service automatically"
 		echo "	--ansi : Don't use colored output."
@@ -188,12 +164,12 @@ while [ -n "$1" ]; do
 			echo "Error: Unknown argument for command show-config: $1"
 			exit 1
 		done
-	elif [ "$1" = "set" ]; then
+	elif [ "$1" = "set-value" ]; then
 		COMMAND=$1
 		CONFIG_KEY=$2
 		CONFIG_VALUE=$3
 		if [ "$#" -ne 3 ]; then
-			echo "ERROR: set command requires two arguments: <key> and <value>"
+			echo "ERROR: set-value command requires two arguments: <key> and <value>"
 			exit 1
 		else
 			shift 2
@@ -229,7 +205,7 @@ init_colors
 #########################################
 # Read Local / Global SDV configuration #
 #########################################
-
+# shellcheck source=/etc/sdv/sdv.conf
 if [ -f "$HOME/.config/sdv.conf" ]; then
 	. "$HOME/.config/sdv.conf"
 	[ "$VERBOSE" = "1" ] && echo "# Config loaded from: $HOME/.config/sdv.conf" && grep -v  '^#' $HOME/.config/sdv.conf | sort -u
@@ -243,6 +219,37 @@ fi
 ######################################################
 #                        commands                    #
 ######################################################
+
+apply_changes() {
+	local TMPFILE="$1"
+	if [ -w ${KANTO_CONFIG} ]; then
+		diff ${TMPFILE} ${KANTO_CONFIG} > /dev/null
+		DIFF_RC=$?
+		if [ "${DIFF_RC}" -eq 1 ]; then
+			BACKUP=$(mktemp --tmpdir kanto-cm-config-backup.XXXXXXX)
+			echo "Backing up to ${BACKUP}"
+			echo "Applying changes:"
+			cp ${KANTO_CONFIG} ${BACKUP}
+			cp ${TMPFILE} ${KANTO_CONFIG}
+			[ "$VERBOSE" = "1" ] &&	echo "Ok, changes applied."
+			CHANGES_APPLIED=1
+		elif [ "${DIFF_RC}" -eq 0 ]; then
+			echo "No difference to existing configuration."
+		else
+			echo "Error ${DIFF_RC} trying to diff config files."
+			exit ${DIFF_RC}
+		fi
+	else
+		echo "Unable to apply changes:"
+		jq < ${TMPFILE}
+		echo "ERROR: No write permissions to ${KANTO_CONFIG}"
+		echo "The changes cannot be applied automatically, as the current user does not have write permissions to ${KANTO_CONFIG}"
+		echo "Either apply the configuration changes manually, or run this script with write permissions (e.g. use sudo):"
+		echo "Run: sudo cp ${TMPFILE} ${KANTO_CONFIG}"
+		exit 1
+	fi
+
+}
 
 # Fragment for a new container registry configuration:
 add_registry() {
@@ -261,28 +268,9 @@ add_registry() {
          } }' < ${KANTO_CONFIG} > ${TMPFILE}
 	[ "$VERBOSE" = "1" ] && echo "Created temp file for modifications: ${TMPFILE}"
 
-	if [ -w ${KANTO_CONFIG} ]; then
-		if ! diff ${TMPFILE} ${KANTO_CONFIG} > /dev/null; then
-			BACKUP=$(mktemp --tmpdir kanto-cm-config-backup.XXXXXXX)
-			echo "Backing up to ${BACKUP}"
-			echo "Applying changes:"
-			cp ${KANTO_CONFIG} ${BACKUP}
-			cp ${TMPFILE} ${KANTO_CONFIG}
-			jq --arg REGISTRY_HOSTNAME "$REGISTRY_HOSTNAME" '.containers.registry_configurations | with_entries(select(.key|contains($REGISTRY_HOSTNAME)))' < ${KANTO_CONFIG} 
-			[ "$VERBOSE" = "1" ] &&	echo "Ok, changes applied."
-			CHANGES_APPLIED=1
-		else
-			echo "No difference to existing configuration."
-		fi
-	else
-		echo "Unable to apply changes:"
-		jq --arg REGISTRY_HOSTNAME "$REGISTRY_HOSTNAME" '.containers.registry_configurations | with_entries(select(.key|contains($REGISTRY_HOSTNAME)))' < ${TMPFILE} 
-		echo "ERROR: No write permissions to ${KANTO_CONFIG}"
-		echo "The changes cannot be applied automatically, as the current user does not have write permissions to ${KANTO_CONFIG}"
-		echo "Either apply the configuration changes manually, or run this script with write permissions (e.g. use sudo):"
-		echo "Run: sudo cp ${TMPFILE} ${KANTO_CONFIG}"
-		exit 1
-	fi
+	apply_changes "${TMPFILE}"
+
+	jq --arg REGISTRY_HOSTNAME "$REGISTRY_HOSTNAME" '.containers.registry_configurations | with_entries(select(.key|contains($REGISTRY_HOSTNAME)))' < ${KANTO_CONFIG} 
 }
 
 remove_registry() {
@@ -295,28 +283,9 @@ remove_registry() {
 	
 	[ "$VERBOSE" = "1" ] && echo "Created temp file for modifications: ${TMPFILE}"
 
-	if [ -w ${KANTO_CONFIG} ]; then
-		if ! diff ${TMPFILE} ${KANTO_CONFIG} > /dev/null; then
-			BACKUP=$(mktemp --tmpdir kanto-cm-config-backup.XXXXXXX)
-			echo "Backing up to ${BACKUP}"
-			echo "Applying changes:"
-			cp ${KANTO_CONFIG} ${BACKUP}
-			cp ${TMPFILE} ${KANTO_CONFIG}
-			jq '.containers.registry_configurations' < ${KANTO_CONFIG} 
-			[ "$VERBOSE" = "1" ] &&	echo "Ok, changes applied."
-			CHANGES_APPLIED=1
-		else
-			echo "No difference to existing configuration."
-		fi
-	else
-		echo "Unable to apply changes:"
-		jq '.containers.registry_configurations' < ${TMPFILE} 
-		echo "ERROR: No write permissions to ${KANTO_CONFIG}"
-		echo "The changes cannot be applied automatically, as the current user does not have write permissions to ${KANTO_CONFIG}"
-		echo "Either apply the configuration changes manually, or run this script with write permissions (e.g. use sudo):"
-		echo "Run: sudo cp ${TMPFILE} ${KANTO_CONFIG}"
-		exit 1
-	fi
+	apply_changes "${TMPFILE}"
+
+	jq '.containers.registry_configurations' < ${TMPFILE}
 }
 
 remove_all_registries() {
@@ -329,28 +298,9 @@ remove_all_registries() {
 	
 	[ "$VERBOSE" = "1" ] && echo "Created temp file for modifications: ${TMPFILE}"
 
-	if [ -w ${KANTO_CONFIG} ]; then
-		if ! diff ${TMPFILE} ${KANTO_CONFIG} > /dev/null; then
-			BACKUP=$(mktemp --tmpdir kanto-cm-config-backup.XXXXXXX)
-			echo "Backing up to ${BACKUP}"
-			echo "Applying changes:"
-			cp ${KANTO_CONFIG} ${BACKUP}
-			cp ${TMPFILE} ${KANTO_CONFIG}
-			jq < ${KANTO_CONFIG} 
-			[ "$VERBOSE" = "1" ] &&	echo "Ok, changes applied."
-			CHANGES_APPLIED=1
-		else
-			echo "No difference to existing configuration."
-		fi
-	else
-		echo "Unable to apply changes:"
-		jq < ${TMPFILE} 
-		echo "ERROR: No write permissions to ${KANTO_CONFIG}"
-		echo "The changes cannot be applied automatically, as the current user does not have write permissions to ${KANTO_CONFIG}"
-		echo "Either apply the configuration changes manually, or run this script with write permissions (e.g. use sudo):"
-		echo "Run: sudo cp ${TMPFILE} ${KANTO_CONFIG}"
-		exit 1
-	fi
+	apply_changes "${TMPFILE}"
+	
+	jq < ${TMPFILE}
 }
 
 list_registries() {
@@ -371,26 +321,9 @@ set_config() {
 	'setpath( $CONFIG_KEY|split(".")[1:]; $CONFIG_VALUE)' < ${KANTO_CONFIG} > ${TMPFILE}
 	[ "$VERBOSE" = "1" ] && echo "Created temp file for modifications: ${TMPFILE}"
 
-	if [ -w ${KANTO_CONFIG} ]; then
-		if ! diff ${TMPFILE} ${KANTO_CONFIG} > /dev/null; then
-			BACKUP=$(mktemp --tmpdir kanto-cm-config-backup.XXXXXXX)
-			echo "Backing up to ${BACKUP}"
-			cp ${KANTO_CONFIG} ${BACKUP}
-			cp ${TMPFILE} ${KANTO_CONFIG}
-			[ "$VERBOSE" = "1" ] &&	echo "Ok, changes applied."
-			CHANGES_APPLIED=1
-		else
-			echo "No difference to existing configuration."
-		fi
-	else
-		echo "ERROR: No write permissions to ${KANTO_CONFIG}"
-		jq < ${TMPFILE}
-		echo "The changes cannot be applied automatically, as the current user does not have write permissions to ${KANTO_CONFIG}"
-		echo "Either apply the configuration changes manually, or run this script with write permissions (e.g. use sudo):"
-		echo "Run: sudo cp ${TMPFILE} ${KANTO_CONFIG}"
-		exit 1
-	fi
-
+	apply_changes "${TMPFILE}"
+	
+	jq < ${TMPFILE}
 }
 
 ######################################################
@@ -407,7 +340,7 @@ fi
 [ "$COMMAND" = "remove-all-registries" ] && remove_all_registries
 [ "$COMMAND" = "list-registries" ] && list_registries
 [ "$COMMAND" = "show-config" ] && show_config
-[ "$COMMAND" = "set" ] && set_config
+[ "$COMMAND" = "set-value" ] && set_config
 
 if [ "$CHANGES_APPLIED" ]; then
 	if [ "${RELOAD}" ]; then

--- a/src/sh/sdv-kanto-ctl
+++ b/src/sh/sdv-kanto-ctl
@@ -1,0 +1,345 @@
+#!/bin/sh
+# shellcheck disable=SC3043
+# shellcheck disable=SC1091
+# shellcheck disable=SC2086
+# shellcheck disable=SC2034
+# shellcheck disable=SC2059
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+
+#### Default config values ####
+VERBOSE=0
+
+### CONSTANTS below
+
+# kanto paths
+KANTO_CMD="kanto-cm"
+KANTO_CONFIG="/etc/container-management/config.json"
+KANTO_SOCK=/run/container-management/container-management.sock
+
+# colors
+COL_NC='\e[39m'
+COL_RED='\e[31m'
+COL_GREEN='\e[32m'
+COL_YELLOW='\e[33m'
+COL_BLUE='\e[34m'
+COL_GRAY='\e[90m'
+COL_WHITE='\e[97m'
+COL_NC_BOLD='\e[1;39m'
+
+init_colors() {
+	export TEXT_OK="${COL_GREEN}OK${COL_NC}"
+	export TEXT_NOTICE="${COL_YELLOW}N/A${COL_NC}"
+	export TEXT_WARN="${COL_YELLOW}WARNING${COL_NC}"
+	export TEXT_FAIL="${COL_RED}FAILED!${COL_NC}"
+	export SEPARATOR="${COL_GRAY}-----------------------------------------------------------${COL_NC}"
+}
+
+cm_get_container_id ()
+{
+	local CONT_NAME=$1
+	${KANTO_CMD} get -n $CONT_NAME 2>/dev/null | jq -r " .container_id"
+}
+
+cm_check_logging_type ()
+{
+	local CONT_ID=$1
+	${KANTO_CMD} get ${CONT_ID} | jq -r " .host_config.log_config.driver_config.type"
+}
+
+cm_get_container_logs () # get the last n (following tail syntax) lines of a container's logs by name
+{
+	local CONT_NAME=$1
+	local LOG_MAX_LINES=$2
+	CONT_ID=$(cm_get_container_id $CONT_NAME)
+	if [ $CONT_ID ]; then
+		LOGGING_TYPE=$(cm_check_logging_type $CONT_ID)
+		if [ $LOGGING_TYPE = "json-file" ]; then # according to kanto docs logging type is either "json-file" (to json.log) or "none"
+			tail -n $LOG_MAX_LINES ${KANTO_CM_HOME_DIR}/containers/${CONT_ID}/${KANTO_CM_LOG_FILE}
+		fi
+	fi
+}
+
+######################################################
+#                        setup                       #
+######################################################
+
+display_help() {
+		echo "Eclipse Kanto Container Manager Configuration Utility"
+		echo "See https://websites.eclipseprojects.io/kanto/docs/references/containers/container-manager-config/"
+		echo "Usage: $0 <command> {options}"
+		echo "Commands:"
+		echo "	add-registry -h <hostname> -u <username> -p <password>"
+		echo "		Adds or replaces a container registry authentication configuration"
+		echo "		-h or --hostname: Configure the hostname of the container registry (e.g. hub.docker.io, ghcr.io, ...)" 
+		echo "		-u or --username: Configure the username" 
+		echo "		-p or --password: Configure the password" 
+		echo "	remove-registry -h"
+		echo "		Removes the specified container registry"
+		echo "		-h or --hostname: The hostname of the container registry" 
+		echo "	remove-all-registries"
+		echo "		Removes all configured container registries"
+		echo "Options:"
+		echo "	--reload : Reload the configuration and restart the container-management service automatically"
+		echo "	--ansi : Don't use colored output."
+		echo "	--verbose | -v : Enable verbose mode."
+		echo "	--help : This message."
+		echo
+		exit 0
+}
+
+while [ -n "$1" ]; do
+	if [ "$1" = "add-registry" ]; then
+		COMMAND=$1
+		shift
+		while [ -n "$1" ]; do 
+			if [ "$1" = "-u" ] || [ "$1" = "--username" ]; then
+				if [ -n "$2" ];	then
+					shift
+					REGISTRY_USERNAME="$1"
+				fi;
+			elif [ "$1" = "-p" ] || [ "$1" = "--password" ]; then
+				if [ -n "$2" ];	then
+					shift
+					REGISTRY_PASSWORD="$1"
+				fi;
+			elif [ "$1" = "-h" ] || [ "$1" = "--hostname" ]; then
+				if [ -n "$2" ];	then
+					shift
+					REGISTRY_HOSTNAME="$1"
+				fi;
+			else
+				echo "Error: Unknown argument for command add-registry: $1"
+				exit 1
+			fi
+			shift
+		done
+		if [ -z "${REGISTRY_USERNAME}" ] || [ -z "${REGISTRY_PASSWORD}" ] || [ -z "${REGISTRY_HOSTNAME}" ]; then
+			echo "Error: missing arguments for command add-registry"
+			echo "Usage:"
+			echo "	$0 add-registry -h <hostname> -u <username> -p <password>"
+			echo "	$0 --reload add-registry --hostname <hostname> --username <username> --password <password>"
+			exit 1
+		fi
+	elif [ "$1" = "remove-registry" ]; then
+		COMMAND=$1
+		shift
+		while [ -n "$1" ]; do 
+			if [ "$1" = "-h" ] || [ "$1" = "--hostname" ]; then
+				if [ -n "$2" ];	then
+					shift
+					REGISTRY_HOSTNAME="$1"
+				fi;
+			else
+				echo "Error: Unknown argument for command remove-registry: $1"
+				exit 1
+			fi
+			shift
+		done
+		if [ -z "${REGISTRY_HOSTNAME}" ]; then
+			echo "Error: missing arguments for command remove-registry"
+			echo "Usage:"
+			echo "	$0 remove-registry -h <hostname>"
+			echo "	$0 --reload remove-registry --hostname <hostname>"
+			exit 1
+		fi
+	elif [ "$1" = "remove-all-registries" ]; then
+		COMMAND=$1
+		shift
+		while [ -n "$1" ]; do 
+			echo "Error: Unknown argument for command remove-all-registries: $1"
+			exit 1
+		done
+
+	elif [ "$1" = "--reload" ] || [ "$1" = "-r" ]; then
+		RELOAD=1
+	elif [ "$1" = "--verbose" ] || [ "$1" = "-v" ]; then
+		VERBOSE=1
+	elif [ "$1" = "--ansi" ]; then
+		# reset COL_XX for monochrome output
+		export COL_NC=""
+		export COL_RED=""
+		export COL_GREEN=""
+		export COL_YELLOW=""
+		export COL_BLUE=""
+		export COL_WHITE=""
+		export COL_GRAY=""
+		export COL_NC_BOLD=""
+	elif [ "$1" = "--help" ]; then
+		display_help
+	else
+		echo "ERROR: Unkown command or option: $1";
+		echo "Try $0 --help"
+		exit 1
+	fi
+	if [ "$#" -gt 0 ]; then
+		shift
+    fi
+done
+
+init_colors
+
+#########################################
+# Read Local / Global SDV configuration #
+#########################################
+
+if [ -f "$HOME/.config/sdv.conf" ]; then
+	. "$HOME/.config/sdv.conf"
+	[ "$VERBOSE" = "1" ] && echo "# Config loaded from: $HOME/.config/sdv.conf" && grep -v  '^#' $HOME/.config/sdv.conf | sort -u
+elif [ -f "/etc/sdv/sdv.conf" ]; then
+	. "/etc/sdv/sdv.conf"
+	[ "$VERBOSE" = "1" ] && echo "# Config loaded from: /etc/sdv/sdv.conf" && grep -v  '^#' /etc/sdv/sdv.conf | sort -u
+else
+	[ "$VERBOSE" = "1" ] && echo "# Config file not found!"
+fi
+
+######################################################
+#                        commands                    #
+######################################################
+
+# Fragment for a new container registry configuration:
+add_registry() {
+	echo "Adding container registry $REGISTRY_HOSTNAME"
+	TMPFILE=$(mktemp --tmpdir kanto-cm-config.XXXXXXX)
+	jq \
+	--arg REGISTRY_HOSTNAME "$REGISTRY_HOSTNAME" \
+	--arg REGISTRY_USERNAME "$REGISTRY_USERNAME" \
+	--arg REGISTRY_PASSWORD "$REGISTRY_PASSWORD" \
+	'.containers.registry_configurations += {
+         ($REGISTRY_HOSTNAME): {
+             "credentials": {
+                 "user_id": $REGISTRY_USERNAME,
+                 "password": $REGISTRY_PASSWORD
+             }
+         } }' < ${KANTO_CONFIG} > ${TMPFILE}
+	[ "$VERBOSE" = "1" ] && echo "Created temp file for modifications: ${TMPFILE}"
+
+	if [ -w ${KANTO_CONFIG} ]; then
+		if ! diff ${TMPFILE} ${KANTO_CONFIG} > /dev/null; then
+			BACKUP=$(mktemp )
+			[ "$VERBOSE" = "1" ] && echo "Backing up to ${BACKUP}"
+			echo "Applying changes:"
+			cp ${KANTO_CONFIG} ${BACKUP}
+			cp ${TMPFILE} ${KANTO_CONFIG}
+			jq --arg REGISTRY_HOSTNAME "$REGISTRY_HOSTNAME" '.containers.registry_configurations | with_entries(select(.key|contains($REGISTRY_HOSTNAME)))' < ${KANTO_CONFIG} 
+			[ "$VERBOSE" = "1" ] &&	echo "Ok, changes applied."
+			CHANGES_APPLIED=1
+		else
+			echo "No difference to existing configuration."
+		fi
+	else
+		echo "Unable to apply changes:"
+		jq --arg REGISTRY_HOSTNAME "$REGISTRY_HOSTNAME" '.containers.registry_configurations | with_entries(select(.key|contains($REGISTRY_HOSTNAME)))' < ${TMPFILE} 
+		echo "ERROR: No write permissions to ${KANTO_CONFIG}"
+		echo "The changes cannot be applied automatically, as the current user does not have write permissions to ${KANTO_CONFIG}"
+		echo "Either apply the configuration changes manually, or run this script with write permissions (e.g. use sudo):"
+		echo "	Run:  sudo cp ${TMPFILE} ${KANTO_CONFIG}"
+		exit 1
+	fi
+}
+
+remove_registry() {
+	echo "Removing container registry $REGISTRY_HOSTNAME"
+	TMPFILE=$(mktemp --tmpdir kanto-cm-config.XXXXXXX)
+	
+	jq \
+	--arg REGISTRY_HOSTNAME "$REGISTRY_HOSTNAME" \
+	'del(.containers.registry_configurations[$REGISTRY_HOSTNAME])' < ${KANTO_CONFIG} > ${TMPFILE}
+	
+	[ "$VERBOSE" = "1" ] && echo "Created temp file for modifications: ${TMPFILE}"
+
+	if [ -w ${KANTO_CONFIG} ]; then
+		if ! diff ${TMPFILE} ${KANTO_CONFIG} > /dev/null; then
+			BACKUP=$(mktemp )
+			[ "$VERBOSE" = "1" ] && echo "Backing up to ${BACKUP}"
+			echo "Applying changes:"
+			cp ${KANTO_CONFIG} ${BACKUP}
+			cp ${TMPFILE} ${KANTO_CONFIG}
+			jq '.containers.registry_configurations' < ${KANTO_CONFIG} 
+			[ "$VERBOSE" = "1" ] &&	echo "Ok, changes applied."
+			CHANGES_APPLIED=1
+		else
+			echo "No difference to existing configuration."
+		fi
+	else
+		echo "Unable to apply changes:"
+		jq '.containers.registry_configurations' < ${TMPFILE} 
+		echo "ERROR: No write permissions to ${KANTO_CONFIG}"
+		echo "The changes cannot be applied automatically, as the current user does not have write permissions to ${KANTO_CONFIG}"
+		echo "Either apply the configuration changes manually, or run this script with write permissions (e.g. use sudo):"
+		echo "	Run:  sudo cp ${TMPFILE} ${KANTO_CONFIG}"
+		exit 1
+	fi
+}
+
+remove_all_registries() {
+	echo "Removing all configured container registries"
+	TMPFILE=$(mktemp --tmpdir kanto-cm-config.XXXXXXX)
+	
+	jq \
+	--arg REGISTRY_HOSTNAME "$REGISTRY_HOSTNAME" \
+	'del(.containers.registry_configurations)' < ${KANTO_CONFIG} > ${TMPFILE}
+	
+	[ "$VERBOSE" = "1" ] && echo "Created temp file for modifications: ${TMPFILE}"
+
+	if [ -w ${KANTO_CONFIG} ]; then
+		if ! diff ${TMPFILE} ${KANTO_CONFIG} > /dev/null; then
+			BACKUP=$(mktemp )
+			[ "$VERBOSE" = "1" ] && echo "Backing up to ${BACKUP}"
+			echo "Applying changes:"
+			cp ${KANTO_CONFIG} ${BACKUP}
+			cp ${TMPFILE} ${KANTO_CONFIG}
+			jq < ${KANTO_CONFIG} 
+			[ "$VERBOSE" = "1" ] &&	echo "Ok, changes applied."
+			CHANGES_APPLIED=1
+		else
+			echo "No difference to existing configuration."
+		fi
+	else
+		echo "Unable to apply changes:"
+		jq < ${TMPFILE} 
+		echo "ERROR: No write permissions to ${KANTO_CONFIG}"
+		echo "The changes cannot be applied automatically, as the current user does not have write permissions to ${KANTO_CONFIG}"
+		echo "Either apply the configuration changes manually, or run this script with write permissions (e.g. use sudo):"
+		echo "	Run:  sudo cp ${TMPFILE} ${KANTO_CONFIG}"
+		exit 1
+	fi
+}
+
+######################################################
+#                        main                        #
+######################################################
+
+if [ -z "$COMMAND" ]; then
+	display_help
+	exit 0
+fi 
+
+[ "$COMMAND" = "add-registry" ] && add_registry
+[ "$COMMAND" = "remove-registry" ] && remove_registry
+[ "$COMMAND" = "remove-all-registries" ] && remove_all_registries
+
+if [ "$CHANGES_APPLIED" ]; then
+	if [ "${RELOAD}" ]; then
+		[ "$VERBOSE" = "1" ] &&	echo "Restarting Kanto Container-Management to apply changes..."
+		systemctl restart container-management
+		[ "$VERBOSE" = "1" ] &&	echo "Restart done."
+	else
+		echo "Note: Kanto requires a restart for the changes to take affect."
+	fi
+else
+	echo "Warning: No changes have been applied."
+fi
+
+exit 0

--- a/src/sh/sdv-kanto-ctl
+++ b/src/sh/sdv-kanto-ctl
@@ -20,6 +20,7 @@
 
 #### Default config values ####
 VERBOSE=0
+RELOAD=1
 
 ### CONSTANTS below
 
@@ -85,13 +86,21 @@ display_help() {
 		echo "		-h or --hostname: Configure the hostname of the container registry (e.g. hub.docker.io, ghcr.io, ...)" 
 		echo "		-u or --username: Configure the username" 
 		echo "		-p or --password: Configure the password" 
-		echo "	remove-registry -h"
+		echo "	remove-registry -h <hostname>"
 		echo "		Removes the specified container registry"
 		echo "		-h or --hostname: The hostname of the container registry" 
 		echo "	remove-all-registries"
 		echo "		Removes all configured container registries"
+		echo "	list-registries"
+		echo "		Prints all configured container registries"
+		echo "	show-config"
+		echo "		Print the container management configuration"
+		echo "	set <key> <value>"
+		echo "		Set a primitive configuration value. Key in JSON Dot-Notation"
+		echo "		Examples: $0 set containers.registry_configurations.MyRegistry.credentials.password foobar"
+		echo "		          $0 set things.enable true"
 		echo "Options:"
-		echo "	--reload : Reload the configuration and restart the container-management service automatically"
+		echo "	--no-reload : Do not reload the configuration and restart the container-management service automatically"
 		echo "	--ansi : Don't use colored output."
 		echo "	--verbose | -v : Enable verbose mode."
 		echo "	--help : This message."
@@ -129,7 +138,11 @@ while [ -n "$1" ]; do
 			echo "Error: missing arguments for command add-registry"
 			echo "Usage:"
 			echo "	$0 add-registry -h <hostname> -u <username> -p <password>"
-			echo "	$0 --reload add-registry --hostname <hostname> --username <username> --password <password>"
+			echo "	$0 add-registry --hostname <hostname> --username <username> --password <password>"
+			echo ""
+			echo "Note: For GitHub Container Registry, you can use a Personal Access Token (PAT) as password."
+			echo "Example:"
+			echo " $0 add-registry -h ghcr.io -u github -p <YOUR_PAT>"
 			exit 1
 		fi
 	elif [ "$1" = "remove-registry" ]; then
@@ -161,9 +174,32 @@ while [ -n "$1" ]; do
 			echo "Error: Unknown argument for command remove-all-registries: $1"
 			exit 1
 		done
-
-	elif [ "$1" = "--reload" ] || [ "$1" = "-r" ]; then
-		RELOAD=1
+	elif [ "$1" = "list-registries" ]; then
+		COMMAND=$1
+		shift
+		while [ -n "$1" ]; do 
+			echo "Error: Unknown argument for command list-registries: $1"
+			exit 1
+		done
+	elif [ "$1" = "show-config" ]; then
+		COMMAND=$1
+		shift
+		while [ -n "$1" ]; do 
+			echo "Error: Unknown argument for command show-config: $1"
+			exit 1
+		done
+	elif [ "$1" = "set" ]; then
+		COMMAND=$1
+		CONFIG_KEY=$2
+		CONFIG_VALUE=$3
+		if [ "$#" -ne 3 ]; then
+			echo "ERROR: set command requires two arguments: <key> and <value>"
+			exit 1
+		else
+			shift 2
+		fi
+	elif [ "$1" = "--no-reload" ] || [ "$1" = "-r" ]; then
+		RELOAD=0
 	elif [ "$1" = "--verbose" ] || [ "$1" = "-v" ]; then
 		VERBOSE=1
 	elif [ "$1" = "--ansi" ]; then
@@ -227,8 +263,8 @@ add_registry() {
 
 	if [ -w ${KANTO_CONFIG} ]; then
 		if ! diff ${TMPFILE} ${KANTO_CONFIG} > /dev/null; then
-			BACKUP=$(mktemp )
-			[ "$VERBOSE" = "1" ] && echo "Backing up to ${BACKUP}"
+			BACKUP=$(mktemp --tmpdir kanto-cm-config-backup.XXXXXXX)
+			echo "Backing up to ${BACKUP}"
 			echo "Applying changes:"
 			cp ${KANTO_CONFIG} ${BACKUP}
 			cp ${TMPFILE} ${KANTO_CONFIG}
@@ -244,7 +280,7 @@ add_registry() {
 		echo "ERROR: No write permissions to ${KANTO_CONFIG}"
 		echo "The changes cannot be applied automatically, as the current user does not have write permissions to ${KANTO_CONFIG}"
 		echo "Either apply the configuration changes manually, or run this script with write permissions (e.g. use sudo):"
-		echo "	Run:  sudo cp ${TMPFILE} ${KANTO_CONFIG}"
+		echo "Run: sudo cp ${TMPFILE} ${KANTO_CONFIG}"
 		exit 1
 	fi
 }
@@ -261,8 +297,8 @@ remove_registry() {
 
 	if [ -w ${KANTO_CONFIG} ]; then
 		if ! diff ${TMPFILE} ${KANTO_CONFIG} > /dev/null; then
-			BACKUP=$(mktemp )
-			[ "$VERBOSE" = "1" ] && echo "Backing up to ${BACKUP}"
+			BACKUP=$(mktemp --tmpdir kanto-cm-config-backup.XXXXXXX)
+			echo "Backing up to ${BACKUP}"
 			echo "Applying changes:"
 			cp ${KANTO_CONFIG} ${BACKUP}
 			cp ${TMPFILE} ${KANTO_CONFIG}
@@ -278,7 +314,7 @@ remove_registry() {
 		echo "ERROR: No write permissions to ${KANTO_CONFIG}"
 		echo "The changes cannot be applied automatically, as the current user does not have write permissions to ${KANTO_CONFIG}"
 		echo "Either apply the configuration changes manually, or run this script with write permissions (e.g. use sudo):"
-		echo "	Run:  sudo cp ${TMPFILE} ${KANTO_CONFIG}"
+		echo "Run: sudo cp ${TMPFILE} ${KANTO_CONFIG}"
 		exit 1
 	fi
 }
@@ -295,8 +331,8 @@ remove_all_registries() {
 
 	if [ -w ${KANTO_CONFIG} ]; then
 		if ! diff ${TMPFILE} ${KANTO_CONFIG} > /dev/null; then
-			BACKUP=$(mktemp )
-			[ "$VERBOSE" = "1" ] && echo "Backing up to ${BACKUP}"
+			BACKUP=$(mktemp --tmpdir kanto-cm-config-backup.XXXXXXX)
+			echo "Backing up to ${BACKUP}"
 			echo "Applying changes:"
 			cp ${KANTO_CONFIG} ${BACKUP}
 			cp ${TMPFILE} ${KANTO_CONFIG}
@@ -312,9 +348,49 @@ remove_all_registries() {
 		echo "ERROR: No write permissions to ${KANTO_CONFIG}"
 		echo "The changes cannot be applied automatically, as the current user does not have write permissions to ${KANTO_CONFIG}"
 		echo "Either apply the configuration changes manually, or run this script with write permissions (e.g. use sudo):"
-		echo "	Run:  sudo cp ${TMPFILE} ${KANTO_CONFIG}"
+		echo "Run: sudo cp ${TMPFILE} ${KANTO_CONFIG}"
 		exit 1
 	fi
+}
+
+list_registries() {
+	jq '.containers.registry_configurations | keys[]' < ${KANTO_CONFIG}
+}
+
+show_config() {
+	jq < ${KANTO_CONFIG}
+}
+
+set_config() {
+	echo "Setting configuration $CONFIG_KEY to $CONFIG_VALUE"
+	TMPFILE=$(mktemp --tmpdir kanto-cm-config.XXXXXXX)
+	CONFIG_KEY=".${CONFIG_KEY}"
+	jq \
+	--arg CONFIG_KEY "$CONFIG_KEY" \
+	--arg CONFIG_VALUE "$CONFIG_VALUE" \
+	'setpath( $CONFIG_KEY|split(".")[1:]; $CONFIG_VALUE)' < ${KANTO_CONFIG} > ${TMPFILE}
+	[ "$VERBOSE" = "1" ] && echo "Created temp file for modifications: ${TMPFILE}"
+
+	if [ -w ${KANTO_CONFIG} ]; then
+		if ! diff ${TMPFILE} ${KANTO_CONFIG} > /dev/null; then
+			BACKUP=$(mktemp --tmpdir kanto-cm-config-backup.XXXXXXX)
+			echo "Backing up to ${BACKUP}"
+			cp ${KANTO_CONFIG} ${BACKUP}
+			cp ${TMPFILE} ${KANTO_CONFIG}
+			[ "$VERBOSE" = "1" ] &&	echo "Ok, changes applied."
+			CHANGES_APPLIED=1
+		else
+			echo "No difference to existing configuration."
+		fi
+	else
+		echo "ERROR: No write permissions to ${KANTO_CONFIG}"
+		jq < ${TMPFILE}
+		echo "The changes cannot be applied automatically, as the current user does not have write permissions to ${KANTO_CONFIG}"
+		echo "Either apply the configuration changes manually, or run this script with write permissions (e.g. use sudo):"
+		echo "Run: sudo cp ${TMPFILE} ${KANTO_CONFIG}"
+		exit 1
+	fi
+
 }
 
 ######################################################
@@ -329,17 +405,18 @@ fi
 [ "$COMMAND" = "add-registry" ] && add_registry
 [ "$COMMAND" = "remove-registry" ] && remove_registry
 [ "$COMMAND" = "remove-all-registries" ] && remove_all_registries
+[ "$COMMAND" = "list-registries" ] && list_registries
+[ "$COMMAND" = "show-config" ] && show_config
+[ "$COMMAND" = "set" ] && set_config
 
 if [ "$CHANGES_APPLIED" ]; then
 	if [ "${RELOAD}" ]; then
-		[ "$VERBOSE" = "1" ] &&	echo "Restarting Kanto Container-Management to apply changes..."
+		echo "Restarting Kanto Container-Management to apply changes..."
 		systemctl restart container-management
 		[ "$VERBOSE" = "1" ] &&	echo "Restart done."
 	else
 		echo "Note: Kanto requires a restart for the changes to take affect."
 	fi
-else
-	echo "Warning: No changes have been applied."
 fi
 
 exit 0

--- a/src/sh/sdv-kanto-ctl
+++ b/src/sh/sdv-kanto-ctl
@@ -332,7 +332,6 @@ set_config() {
 
 if [ -z "$COMMAND" ]; then
 	display_help
-	exit 0
 fi 
 
 [ "$COMMAND" = "add-registry" ] && add_registry

--- a/src/sh/sdv-motd
+++ b/src/sh/sdv-motd
@@ -73,7 +73,8 @@ IP_NET=$(ip a s "${NET_DEV}" | grep -E -o 'inet [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,
 # Fancy status report
 # shellcheck disable=SC3037
 # shellcheck disable=SC1091
-echo "\033[1;32m
+# shellcheck disable=SC2059
+printf "\033[1;32m
 \033[1;32m \033[0;37mHostname......: \033[1;33m$HOST_NAME
 \033[1;31m \033[0;37mUptime........: $UP1 days, $UP2:$UP3 hours
 \033[1;31m \033[0;37m\0303\0230 System load.: $LOAD1 (1min) \t| $LOAD2 (5min) \t| $LOAD3 (15min)
@@ -81,7 +82,7 @@ echo "\033[1;32m
 \033[1;31m \033[0;37m                Data: $DATA_DISK1 \t| Used: $DATA_DISK2 \t| Free: $DATA_DISK3
 \033[1;31m \033[0;37mRAM ..........: Total: $RAM1 \t| Used: $RAM2 \t| Free: $RAM3
 \033[1;31m \033[0;37mNetwork.......: Interface : \033[1;35m$NET_DEV
-\033[1;31m \033[0;37m                IP Address: \033[1;35m$IP_NET"
+\033[1;31m \033[0;37m                IP Address: \033[1;35m$IP_NET\n"
 
 # Containers stats
 if [ -w /run/container-management/container-management.sock ]; then
@@ -89,7 +90,7 @@ if [ -w /run/container-management/container-management.sock ]; then
     CONTAINERS_RUNNING=$(kanto-cm list | grep -c Running)
     CONTAINERS_STOPPED=$(kanto-cm list | grep -c Stopped)
     CONTAINERS_EXITED=$(kanto-cm list | grep -c Exited)
-    echo "\033[1;31m \033[0;37mContainers....: ${CONTAINERS_RUNNING} running \t| ${CONTAINERS_STOPPED} stopped \t| ${CONTAINERS_EXITED} exited\033[m\n"
+    printf "\033[1;31m \033[0;37mContainers....: ${CONTAINERS_RUNNING} running \t| ${CONTAINERS_STOPPED} stopped \t| ${CONTAINERS_EXITED} exited\033[m\n"
 fi
 
 printf "\033[mTo check SDV services health, run \033[0;37m$ \033[1;33msdv-health\033[m\n"

--- a/src/sh/sdv-motd
+++ b/src/sh/sdv-motd
@@ -90,7 +90,7 @@ if [ -w /run/container-management/container-management.sock ]; then
     CONTAINERS_RUNNING=$(kanto-cm list | grep -c Running)
     CONTAINERS_STOPPED=$(kanto-cm list | grep -c Stopped)
     CONTAINERS_EXITED=$(kanto-cm list | grep -c Exited)
-    printf "\033[1;31m \033[0;37mContainers....: ${CONTAINERS_RUNNING} running \t| ${CONTAINERS_STOPPED} stopped \t| ${CONTAINERS_EXITED} exited\033[m\n"
+    printf "\033[1;31m \033[0;37mContainers....: %s running \t| %s stopped \t| %s exited\033[m\n" "${CONTAINERS_RUNNING}" "${CONTAINERS_STOPPED}" "${CONTAINERS_EXITED}"
 fi
 
 printf "\033[mTo check SDV services health, run \033[0;37m$ \033[1;33msdv-health\033[m\n"

--- a/src/sh/sdv-motd
+++ b/src/sh/sdv-motd
@@ -70,16 +70,10 @@ IP=$(ip address show scope global)
 #IP_ETH0=$(echo "$IP" | awk "/scope global .*${NET_DEV}/ {print $2}" | xargs)
 IP_NET=$(ip a s "${NET_DEV}" | grep -E -o 'inet [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | cut -d' ' -f2)
 
-# Containers stats
-CONTAINERS_TOTAL=$(kanto-cm list | grep -c "Running\|Stopped\|Exited")
-CONTAINERS_RUNNING=$(kanto-cm list | grep -c Running)
-CONTAINERS_STOPPED=$(kanto-cm list | grep -c Stopped)
-CONTAINERS_EXITED=$(kanto-cm list | grep -c Exited)
-
 # Fancy status report
 # shellcheck disable=SC3037
 # shellcheck disable=SC1091
-echo -e "\033[1;32m
+echo "\033[1;32m
 \033[1;32m \033[0;37mHostname......: \033[1;33m$HOST_NAME
 \033[1;31m \033[0;37mUptime........: $UP1 days, $UP2:$UP3 hours
 \033[1;31m \033[0;37m\0303\0230 System load.: $LOAD1 (1min) \t| $LOAD2 (5min) \t| $LOAD3 (15min)
@@ -87,11 +81,18 @@ echo -e "\033[1;32m
 \033[1;31m \033[0;37m                Data: $DATA_DISK1 \t| Used: $DATA_DISK2 \t| Free: $DATA_DISK3
 \033[1;31m \033[0;37mRAM ..........: Total: $RAM1 \t| Used: $RAM2 \t| Free: $RAM3
 \033[1;31m \033[0;37mNetwork.......: Interface : \033[1;35m$NET_DEV
-\033[1;31m \033[0;37m                IP Address: \033[1;35m$IP_NET
-\033[1;31m \033[0;37mContainers....: ${CONTAINERS_RUNNING} running \t| ${CONTAINERS_STOPPED} stopped \t| ${CONTAINERS_EXITED} exited
-\033[m"
+\033[1;31m \033[0;37m                IP Address: \033[1;35m$IP_NET"
 
-printf "To check SDV services health, run \033[0;37m$ \033[1;33msdv-health\033[m\n"
+# Containers stats
+if [ -w /run/container-management/container-management.sock ]; then
+    CONTAINERS_TOTAL=$(kanto-cm list | grep -c "Running\|Stopped\|Exited")
+    CONTAINERS_RUNNING=$(kanto-cm list | grep -c Running)
+    CONTAINERS_STOPPED=$(kanto-cm list | grep -c Stopped)
+    CONTAINERS_EXITED=$(kanto-cm list | grep -c Exited)
+    echo "\033[1;31m \033[0;37mContainers....: ${CONTAINERS_RUNNING} running \t| ${CONTAINERS_STOPPED} stopped \t| ${CONTAINERS_EXITED} exited\033[m\n"
+fi
+
+printf "\033[mTo check SDV services health, run \033[0;37m$ \033[1;33msdv-health\033[m\n"
 printf "Use \033[0;37m$ \033[1;33msdv-device-info\033[m to display device configuration\n"
 printf "Use \033[0;37m$ \033[1;33msdv-provision\033[m to generate self-signed device certificates\n"
 printf "\033[m\n"

--- a/src/sh/sdv-provision
+++ b/src/sh/sdv-provision
@@ -12,7 +12,7 @@
 # * SPDX-License-Identifier: Apache-2.0
 # ********************************************************************************/
 # shellcheck disable=SC3043
-
+# shellcheck disable=SC2039
 
 # Generating dummy device certificates (self-signed) according to tutorial
 # https://learn.microsoft.com/en-us/azure/iot-hub/tutorial-x509-self-sign


### PR DESCRIPTION
This PR brings a new shell script to manage Kanto Container Manager configuration:
- Add and Remove "Container Registry Configuration" entries, e.g. authentication credentials for private container registries
- Set arbitrary primitives in the configuration file

The script `sdv-kanto-ctl` as a help. It creates backups of the original configuration file and prints the applied changes.

```
$ ./sdv-kanto-ctl --help
Eclipse Kanto Container Manager Configuration Utility
See https://websites.eclipseprojects.io/kanto/docs/references/containers/container-manager-config/
Usage: ./sdv-kanto-ctl <command> {options}
Commands:
        add-registry -h <hostname> -u <username> -p <password>
                Adds or replaces a container registry authentication configuration
                -h or --hostname: Configure the hostname of the container registry (e.g. hub.docker.io, ghcr.io, ...)
                -u or --username: Configure the username
                -p or --password: Configure the password
        remove-registry -h <hostname>
                Removes the specified container registry
                -h or --hostname: The hostname of the container registry
        remove-all-registries
                Removes all configured container registries
        list-registries
                Prints all configured container registries
        show-config
                Print the container management configuration
        set <key> <value>
                Set a primitive configuration value. Key in JSON Dot-Notation
                Examples: ./sdv-kanto-ctl set containers.registry_configurations.MyRegistry.credentials.password foobar
                          ./sdv-kanto-ctl set things.enable true
Options:
        --no-reload : Do not reload the configuration and restart the container-management service automatically
        --ansi : Don't use colored output.
        --verbose | -v : Enable verbose mode.
        --help : This message.
```