### PR TITLE
KAD to retry on dropped connections to Container Management

### DIFF
--- a/src/rust/kanto-auto-deployer/Cargo.lock
+++ b/src/rust/kanto-auto-deployer/Cargo.lock
@@ -568,14 +568,13 @@ dependencies = [
 
 [[package]]
 name = "kanto-auto-deployer"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",
  "enclose",
  "env_logger",
  "glob",
- "hyper",
  "json-patch",
  "log",
  "notify",

--- a/src/rust/kanto-auto-deployer/Cargo.lock
+++ b/src/rust/kanto-auto-deployer/Cargo.lock
@@ -583,6 +583,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-retry",
  "tokio-stream",
  "tonic",
  "tonic-build",
@@ -1135,6 +1136,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.11",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand",
+ "tokio",
 ]
 
 [[package]]

--- a/src/rust/kanto-auto-deployer/Cargo.lock
+++ b/src/rust/kanto-auto-deployer/Cargo.lock
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "kanto-auto-deployer"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/src/rust/kanto-auto-deployer/Cargo.toml
+++ b/src/rust/kanto-auto-deployer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kanto-auto-deployer"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Automated deployment of Kanto Container Management Manifests"
 license = "Apache-2.0"
@@ -16,7 +16,6 @@ tokio = { version = "1.20.0", features = ["rt-multi-thread"] }
 tokio-stream = { version = "0.1.12", default-features = false}
 tonic = { version = "0.7.2" }
 tower = { version = "0.4.13", default-features=false }
-hyper = { version = "0.14.25" }
 serde = { version = "1.0.147", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.89", default-features = false}
 glob = "0.3.0"

--- a/src/rust/kanto-auto-deployer/Cargo.toml
+++ b/src/rust/kanto-auto-deployer/Cargo.toml
@@ -27,6 +27,7 @@ env_logger = "0.9.3"
 notify = { version = "5.1.0", optional = true }
 clap = { version = "3.2.23", features = ["derive"] }
 enclose = { version = "1.1.8", optional = true }
+tokio-retry = "0.3.0"
 
 [build-dependencies]
 tonic-build = "0.7.2"

--- a/src/rust/kanto-auto-deployer/Cargo.toml
+++ b/src/rust/kanto-auto-deployer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kanto-auto-deployer"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Automated deployment of Kanto Container Management Manifests"
 license = "Apache-2.0"

--- a/src/rust/kanto-auto-deployer/src/fs_watcher.rs
+++ b/src/rust/kanto-auto-deployer/src/fs_watcher.rs
@@ -13,10 +13,7 @@
 
 use notify::{Config, PollWatcher, RecursiveMode, Watcher};
 use std::future::Future;
-use std::{
-    path::Path,
-    time::Duration,
-};
+use std::{path::Path, time::Duration};
 
 pub use notify::Event;
 use tokio::sync::mpsc::{channel, Receiver};

--- a/src/rust/kanto-auto-deployer/src/fs_watcher.rs
+++ b/src/rust/kanto-auto-deployer/src/fs_watcher.rs
@@ -14,7 +14,7 @@
 use notify::{Config, PollWatcher, RecursiveMode, Watcher};
 use std::future::Future;
 use std::{
-    path::{Path, PathBuf},
+    path::Path,
     time::Duration,
 };
 
@@ -63,7 +63,7 @@ where
     Ok(())
 }
 
-pub fn is_filetype(path: &PathBuf, extension: &str) -> bool {
+pub fn is_filetype(path: &Path, extension: &str) -> bool {
     if path.extension().is_none() {
         return false;
     }
@@ -72,5 +72,5 @@ pub fn is_filetype(path: &PathBuf, extension: &str) -> bool {
         return true;
     }
 
-    return false;
+    false
 }

--- a/src/rust/kanto-auto-deployer/src/main.rs
+++ b/src/rust/kanto-auto-deployer/src/main.rs
@@ -85,7 +85,7 @@ impl RetryState {
             RetryTimes::Forever => true,
             RetryTimes::Never => false,
             RetryTimes::Count(c) => {
-                let retries_left = c.checked_sub(1).unwrap_or(0);
+                let retries_left = c.saturating_sub(1);
                 self.retry_times = RetryTimes::Count(retries_left);
                 retries_left > 0
             }

--- a/src/rust/kanto-auto-deployer/src/main.rs
+++ b/src/rust/kanto-auto-deployer/src/main.rs
@@ -215,8 +215,7 @@ async fn deploy(socket: &str, retries: RetryTimes, file_path: &str, recreate: bo
     let container_str = fs::read_to_string(file_path)?;
     let mut _client = get_client(socket, retries).await?;
     let parsed_json = manifest_parser::try_parse_manifest(&container_str);
-    if let Ok(c) = parsed_json {
-        let new_container: kanto_cnt::Container = c;
+    if let Ok(new_container) = parsed_json {
         let _r = tonic::Request::new(kanto::ListContainersRequest {});
         let containers_list = _client.list(_r).await?.into_inner().containers;
         let existing_instance = containers_list

--- a/src/rust/kanto-auto-deployer/src/main.rs
+++ b/src/rust/kanto-auto-deployer/src/main.rs
@@ -63,6 +63,7 @@ struct CliArgs {
 enum RetryTimes {
     Count(u32),
     Forever,
+    Never
 }
 
 struct RetryState {
@@ -78,6 +79,7 @@ impl RetryState {
     fn tick(&mut self) -> bool {
         match self.retry_times {
             RetryTimes::Forever => true,
+            RetryTimes::Never => false,
             RetryTimes::Count(c) => {
                 let retries_left = c.checked_sub(1).unwrap_or(0);
                 self.retry_times = RetryTimes::Count(retries_left);
@@ -231,7 +233,7 @@ async fn deploy_directory(directory_path: &str, socket: &str, retries: RetryTime
 async fn redeploy_on_change(e: fs_watcher::Event, socket: &str) {
     // In daemon mode we wait until a connection is available to proceed
     // Unwrapping in this case is safe.
-    let mut client = get_client(socket, RetryTimes::Forever).await.unwrap();
+    let mut client = get_client(socket, RetryTimes::Never).await.unwrap();
     for path in &e.paths {
         if !is_filetype(path, "json") {
             continue;

--- a/src/rust/kanto-auto-deployer/src/main.rs
+++ b/src/rust/kanto-auto-deployer/src/main.rs
@@ -59,7 +59,9 @@ struct CliArgs {
     daemon: bool,
 }
 
-// Conditional compilation would give warning for unused variants
+static CONN_RETRY_BASE_TIMEOUT_MS: u64 = 100;
+
+// Conditional compilation would give warnings for unused variants
 #[allow(dead_code)]
 #[derive(Clone, Copy, PartialEq)]
 pub enum RetryTimes {
@@ -103,7 +105,7 @@ async fn get_unix_channel(socket_path: &str) -> Result<tonic::transport::Channel
 
 async fn get_client(socket_path: &str, retries: RetryTimes) -> Result<CmClient> {
     let mut retry_state = RetryState::new(retries);
-    let retry_strategy = strategy::FibonacciBackoff::from_millis(10)
+    let retry_strategy = strategy::FibonacciBackoff::from_millis(CONN_RETRY_BASE_TIMEOUT_MS)
         .map(|d| {
             log::debug!("Retrying connection in {} ms", d.as_millis());
             d

--- a/src/rust/kanto-auto-deployer/src/main.rs
+++ b/src/rust/kanto-auto-deployer/src/main.rs
@@ -235,7 +235,7 @@ async fn deploy_directory(directory_path: &str, socket: &str, retries: RetryTime
 async fn redeploy_on_change(e: fs_watcher::Event, socket: &str) {
     // In daemon mode we wait until a connection is available to proceed
     // Unwrapping in this case is safe.
-    let mut client = get_client(socket, RetryTimes::Never).await.unwrap();
+    let mut client = get_client(socket, RetryTimes::Forever).await.unwrap();
     for path in &e.paths {
         if !is_filetype(path, "json") {
             continue;

--- a/src/rust/kanto-auto-deployer/src/main.rs
+++ b/src/rust/kanto-auto-deployer/src/main.rs
@@ -131,7 +131,7 @@ async fn get_client(socket_path: &str, retries: RetryTimes) -> Result<CmClient> 
 
 async fn start(_client: &mut CmClient, name: &str, _id: &str) -> Result<()> {
     log::info!("Starting [{}]", name);
-    let id = String::from(_id.clone());
+    let id = String::from(_id);
     let request = tonic::Request::new(kanto::StartContainerRequest { id });
     let _response = _client.start(request).await?;
     log::info!("Started [{}]", name);
@@ -168,7 +168,7 @@ async fn create(socket: &str, retries: RetryTimes,file_path: &str, recreate: boo
     let parsed_json = manifest_parser::try_parse_manifest(&container_str);
     if let Ok(container) = parsed_json {
         let container: kanto_cnt::Container = container;
-        let name = String::from(container.name.clone());
+        let name = container.name.clone();
         let _r = tonic::Request::new(kanto::ListContainersRequest {});
         let containers = _client.list(_r).await?.into_inner();
         for cont in &containers.containers {


### PR DESCRIPTION
## Problem Description

The availability of the Container-Management UNIX socket cannot be guaranteed. Current solution is to set the systemd unit to be dependent on the container-management one. This is not robust for non-systemd based distros (e.g. those that use sysvinit) and the socket connection might still drop during runtime due to CM being restarted.

That is why retry-logic for connecting to the CM socket in KAD is needed.

## Solution

Previous versions of KAD would not instantiate the socket once and pass a reference to it. While good for performance, this means that if the connection drops not attempts towards re-creation are made.

Now the socket connection is re-established before each container creation with logic to retry n-amount of times/never/forever.  This still leaves a window for failure but it's much smaller, making KAD more robust.

## Performance

This is less optimal than re-using a single connection, but still generally a small amount of creation requests are made  (<10) so it would not severely impact system performance.

## Other changes

- Bugfix: containers that are stopped are started on subsequent runs of KAD (were ignored previously)
- Refactored deployment logic to improve readability/accommodate the bugfix above.