### PR TITLE
Setup OCaaS scanning for SdV fork

### DIFF
--- a/.github/workflows/ocaas.yaml
+++ b/.github/workflows/ocaas.yaml
@@ -25,7 +25,7 @@ on:
  
 jobs:
   ocaas-scan:
-    runs-on: ubuntu-22.04
+    runs-on: self-hosted
     if: github.repository_owner == 'SoftwareDefinedVehicle'
     steps:
       - name: OCaaS Scans

--- a/.github/workflows/ocaas.yaml
+++ b/.github/workflows/ocaas.yaml
@@ -25,7 +25,7 @@ on:
  
 jobs:
   ocaas-scan:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     if: github.repository_owner == 'SoftwareDefinedVehicle'
     steps:
       - name: OCaaS Scans

--- a/.github/workflows/ocaas.yaml
+++ b/.github/workflows/ocaas.yaml
@@ -1,0 +1,56 @@
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+name: OCaaS Compliance checks
+ 
+on:
+  workflow_dispatch:
+  workflow_call:
+  pull_request:
+    types:
+      - opened
+  push:
+    paths:
+      - '.ort.yml'
+ 
+jobs:
+  ocaas-scan:
+    runs-on: ubuntu-22.04
+    if: github.repository_owner == 'SoftwareDefinedVehicle'
+    steps:
+      - name: OCaaS Scans
+        id: ocaas
+        uses: docker://osmipublic.azurecr.io/ocaas-ci:latest
+        continue-on-error: true # Built artifacts also should also be uploaded if the scan finds violations.
+        with:
+          args: auth generate-token run start download
+        env:
+          OCAAS_USERNAME: ${{ secrets.OCAAS_USERNAME }}
+          OCAAS_PASSWORD: ${{ secrets.OCAAS_PASSWORD }}
+          PROJECT_NAME: "Eclipse Leda Yocto Distro"
+          PIPELINE_ID: 377 # Your pipeline ID. Provided by the OSMI team.
+          VCS_URL: ${{ github.server_url }}/${{ github.repository }}.git
+          VCS_REVISION: ${{ github.ref_name }}
+          APPLICATION_CATEGORY: "BT11"
+          BLOCKING: true
+          REPORT_FILES: SCAN_REPORT_WEB_APP_HTML
+          OUTPUT_DIR: reports/
+      - name: Upload reports
+        id: upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: oss-compliance-reports
+          path: reports/
+      - name: Check for violations
+        if: steps.ocaas.outcome != 'success' || steps.upload.outcome != 'success'
+        run: exit 1

--- a/.ort.yml
+++ b/.ort.yml
@@ -21,6 +21,13 @@ package_configurations:
       concluded_license: Apache-2.0
       reason: INCORRECT
       comment: "Kantui and all of its submodules are licensed under Apache-2.0"
+    - path: "src/rust/kanto-tui/src/main.rs"
+      start_lines: "7"
+      line_count: 3
+      detected_license: "GPL-2.0-only"
+      concluded_license: Apache-2.0
+      reason: INCORRECT
+      comment: "Kantui and all of its submodules are licensed under Apache-2.0"
   - id: "Crate::rand_core:0.6.4"
     source_artifact_url: "https://crates.io/api/v1/crates/rand_core/0.6.4/download"
     license_finding_curations:
@@ -37,20 +44,7 @@ package_configurations:
     - pattern: "**/**"
       reason: "OPTIONAL_COMPONENT_OF"
       comment: "The distribution target architectures do not include windows and the crate is dual-licensed under Apache-2.0 or MIT"
-  - id: "Cargo::kantui:0.3.0"
-    vcs:
-      type: "Git"
-      url: "https://github.com/SoftwareDefinedVehicle/leda-utils-fork.git"
-      revision: "ea38c97ce8099ab327d24a8cbfb1fd0a33a43612"
-    license_finding_curations:
-    - path: "src/rust/kanto-tui/src/main.rs"
-      start_lines: "7"
-      line_count: 3
-      detected_license: "GPL-2.0-only"
-      concluded_license: Apache-2.0
-      reason: INCORRECT
-      comment: "Kantui and all of its submodules are licensed under Apache-2.0"
-    
+
 license_choices:
   repository_license_choices:
   - given: "GPL-2.0-or-later OR MIT"

--- a/.ort.yml
+++ b/.ort.yml
@@ -1,51 +1,189 @@
 # Curation for OSS OCaaS findings. For reference, see : https://github.com/oss-review-toolkit/ort/blob/main/docs/config-file-ort-yml.md
+analyzer:
+  skip_excluded: true
 excludes:
   paths:
-  - pattern: "src/rust/kanto-auto-deployer/container-management/**"
-    reason: "BUILD_TOOL_OF"
-    comment: "Container management protobuffers are only used during build time and are licensed under Apache-2.0. No other parts of Container-managament are used"
-  - pattern: "src/rust/kanto-tui/container-management/**"
-    reason: "BUILD_TOOL_OF"
-    comment: "Container management protobuffers are only used during build time and are licensed under Apache-2.0. No other parts of Container-managament are used"
+    - pattern: "src/rust/kanto-auto-deployer/container-management/**"
+      reason: "BUILD_TOOL_OF"
+      comment: "Container management protobuffers are only used during build time and are licensed under Apache-2.0. No other parts of Container-Management are used"
+    - pattern: "src/rust/kanto-tui/container-management/**"
+      reason: "BUILD_TOOL_OF"
+      comment: "Container management protobuffers are only used during build time and are licensed under Apache-2.0. No other parts of Container-Management are used"
+    - pattern: ".devcontainer/**"
+      reason: "BUILD_TOOL_OF"
+      comment: "Dev container scripts are only used during development inside codespaces/vs code devcontainers. All Leda-utils provided scripts are licensed explicitly under Apache-2.0."
 package_configurations:
-  - id: "Cargo::kantui:0.3.0"
-    vcs:
-      type: "Git"
-      url: "https://github.com/SoftwareDefinedVehicle/leda-utils-fork.git"
-      revision: "ea38c97ce8099ab327d24a8cbfb1fd0a33a43612"
-    license_finding_curations:
-    - path: "src/rust/kanto-tui/src/kanto_api.rs"
-      start_lines: "7"
-      line_count: 2
-      detected_license: "LicenseRef-scancode-biosl-4.0"
-      concluded_license: Apache-2.0
-      reason: INCORRECT
-      comment: "Kantui and all of its submodules are licensed under Apache-2.0"
-    - path: "src/rust/kanto-tui/src/main.rs"
-      start_lines: "7"
-      line_count: 3
-      detected_license: "GPL-2.0-only"
-      concluded_license: Apache-2.0
-      reason: INCORRECT
-      comment: "Kantui and all of its submodules are licensed under Apache-2.0"
   - id: "Crate::rand_core:0.6.4"
     source_artifact_url: "https://crates.io/api/v1/crates/rand_core/0.6.4/download"
     license_finding_curations:
-    - path: "rand_core-0.6.4/LICENSE-APACHE"
-      start_lines: "7"
-      line_count: 181
-      detected_license: "ImageMagick"
-      concluded_license: "MIT OR Apache-2.0"
-      reason: INCORRECT
-      comment: "The rand_core crate is dual licensed under Apache-2.0 or MIT"
+      - path: "rand_core-0.6.4/LICENSE-APACHE"
+        start_lines: "7"
+        line_count: 181
+        detected_license: "ImageMagick"
+        concluded_license: "MIT OR Apache-2.0"
+        reason: INCORRECT
+        comment: "The rand_core crate is dual licensed under Apache-2.0 or MIT"
   - id: "Crate::windows:0.48.0"
     source_artifact_url: "https://crates.io/api/v1/crates/windows-sys/0.42.0/download"
     path_excludes:
-    - pattern: "**/**"
-      reason: "OPTIONAL_COMPONENT_OF"
-      comment: "The distribution target architectures do not include windows and the crate is dual-licensed under Apache-2.0 or MIT"
-
+      - pattern: "**/**"
+        reason: "OPTIONAL_COMPONENT_OF"
+        comment: "The distribution target architectures do not include windows and the crate is dual-licensed under Apache-2.0 or MIT"
+    license_finding_curations:
+      - path: "windows-0.48.0/src/Windows/Win32/UI/Shell/mod.rs"
+        start_lines: "53991"
+        line_count: 1
+        detected_license: "Noweb"
+        concluded_license: "MIT OR Apache-2.0"
+        reason: INCORRECT
+        comment: "License of windows crate is Apache-2.0 OR MIT and target architectures do not include windows."
+curations:
+  license_findings:
+    - path: "src/rust/kanto-tui/src/main.rs"
+      detected_license: "GPL-2.0-only"
+      reason: "INCORRECT"
+      comment: "Kantui and all of its sources are explicitly licensed under Apache-2.0 with appropriate SPDX identifiers"
+      concluded_license: "Apache-2.0"
+    - path: "src/rust/kanto-tui/src/kanto_api.rs"
+      detected_license: "LicenseRef-scancode-biosl-4.0"
+      reason: "INCORRECT"
+      comment: "Kantui and all of its sources are explicitly licensed under Apache-2.0 with appropriate SPDX identifiers"
+      concluded_license: "Apache-2.0"
+    - path: "src/sh/sdv-device-info"
+      detected_license: "LicenseRef-scancode-biosl-4.0"
+      reason: "INCORRECT"
+      comment: "Leda shell utilities are explicitly licensed under Apache-2.0 with appropriate SPDX identifiers"
+      concluded_license: "Apache-2.0"
+    - path: "src/sh/sdv-kanto-ctl"
+      detected_license: "LicenseRef-scancode-biosl-4.0"
+      reason: "INCORRECT"
+      comment: "Leda shell utilities are explicitly licensed under Apache-2.0 with appropriate SPDX identifiers"
+      concluded_license: "Apache-2.0"
+    - path: "src/sh/sdv-health"
+      detected_license: "GPL-2.0-only"
+      reason: "INCORRECT"
+      comment: "Leda shell utilities are explicitly licensed under Apache-2.0 with appropriate SPDX identifiers"
+      concluded_license: "Apache-2.0"
+    - path: "src/tests/sdv-ctr-exec-tests.bats"
+      detected_license: "LicenseRef-scancode-biosl-4.0"
+      reason: "INCORRECT"
+      comment: "BATS tests for Leda Shell utilities are explicitly licensed under Apache-2.0 with appropriate SPDX identifiers"
+      concluded_license: "Apache-2.0"
+    - path: "src/tests/sdv-device-info-tests.bats"
+      detected_license: "LicenseRef-scancode-biosl-4.0"
+      reason: "INCORRECT"
+      comment: "BATS tests for Leda Shell utilities are explicitly licensed under Apache-2.0 with appropriate SPDX identifiers"
+      concluded_license: "Apache-2.0"
+    - path: "src/tests/sdv-help-tests.bats"
+      detected_license: "LicenseRef-scancode-biosl-4.0"
+      reason: "INCORRECT"
+      comment: "BATS tests for Leda Shell utilities are explicitly licensed under Apache-2.0 with appropriate SPDX identifiers"
+      concluded_license: "Apache-2.0"
+    - path: "src/tests/sdv-kanto-ctl-tests.bats"
+      detected_license: "LicenseRef-scancode-biosl-4.0"
+      reason: "INCORRECT"
+      comment: "BATS tests for Leda Shell utilities are explicitly licensed under Apache-2.0 with appropriate SPDX identifiers"
+      concluded_license: "Apache-2.0"
+    - path: "src/tests/sdv-provision-tests.bats"
+      detected_license: "LicenseRef-scancode-biosl-4.0"
+      reason: "INCORRECT"
+      comment: "BATS tests for Leda Shell utilities are explicitly licensed under Apache-2.0 with appropriate SPDX identifiers"
+      concluded_license: "Apache-2.0"
+    - path: ".devcontainer/post-start.sh"
+      detected_license: "GPL-2.0-only"
+      reason: "INCORRECT"
+      comment: "Dev container scripts are only used during development inside codespaces/vs code devcontainers. All Leda-utils provided scripts are licensed explicitly under Apache-2.0."
+      concluded_license: "Apache-2.0"
+  packages:
+    - id: "Crate::prost-build:0.10.4"
+      curations:
+        comment: "Licenses were scanned manually in source and effective licenses are concluded.  GPL-3.0-or-later WITH Autoconf-exception-2.0 applies only to ax_pthread.m4 which is a thid-party build dependency of prost-build."
+        concluded_license: "Apache-2.0"
+    - id: "Crate::bytes:1.4.0"
+      curations:
+        comment: "Wrong detection of README file which is not included in final build."
+        concluded_license: "Apache-2.0"
+    - id: "Crate::windows_aarch64_msvc:0.42.2"
+      curations:
+        comment: "Wrong detection of license. Windows targets crate is licensed under MIT or Apache-2.0. https://crates.io/crates/windows-targets Additionally kantui/KAD do not target and do not compile for Windows-based systems."
+        concluded_license: "Apache-2.0"
+    - id: "Crate::windows_i686_msvc:0.42.2"
+      curations:
+        comment: "Wrong detection of license. Windows targets crate is licensed under MIT or Apache-2.0. https://crates.io/crates/windows-targets Additionally kantui/KAD do not target and do not compile for Windows-based systems."
+        concluded_license: "Apache-2.0"
+    - id: "Crate::windows_x86_64_msvc:0.42.2"
+      curations:
+        comment: "Wrong detection of license. Windows targets crate is licensed under MIT or Apache-2.0. https://crates.io/crates/windows-targets Additionally kantui/KAD do not target and do not compile for Windows-based systems."
+        concluded_license: "Apache-2.0"
+    - id: "Crate::windows_x86_64_msvc:0.48.0"
+      curations:
+        comment: "Wrong detection of license. Windows targets crate is licensed under MIT or Apache-2.0. https://crates.io/crates/windows-targets Additionally kantui/KAD do not target and do not compile for Windows-based systems."
+        concluded_license: "Apache-2.0"
+    - id: "Crate::windows_aarch64_msvc:0.48.0"
+      curations:
+        comment: "Wrong detection of license. Windows targets crate is licensed under MIT or Apache-2.0. https://crates.io/crates/windows-targets Additionally kantui/KAD do not target and do not compile for Windows-based systems."
+        concluded_license: "Apache-2.0"
+    - id: "Crate::windows_i686_msvc:0.48.0"
+      curations:
+        comment: "Wrong detection of license. Windows targets crate is licensed under MIT or Apache-2.0. https://crates.io/crates/windows-targets Additionally kantui/KAD do not target and do not compile for Windows-based systems."
+        concluded_license: "Apache-2.0"
+    - id: "Crate::enclose:1.1.8"
+      curations:
+        comment: "Wrong detection of license header."
+        concluded_license: "Apache-2.0"
+    - id: "Crate::tokio:1.27.0"
+      curations:
+        comment: "Wrong detection of README file which is not included in final build anyway."
+        concluded_license: "MIT"
+    - id: "Crate::tokio-macros:2.0.0"
+      curations:
+        comment: "Wrong detection of README and LICENSE files which are not included in final build anyway."
+        concluded_license: "MIT"
+    - id: "Crate::async-stream:0.3.5"
+      curations:
+        comment: "Wrong detection of README and LICENSE files which are not included in final build anyway."
+        concluded_license: "MIT"
+    - id: "Crate::tower:0.4.13"
+      curations:
+        comment: "Wrong detection of README and LICENSE files which are not included in final build anyway."
+        concluded_license: "MIT"
+    - id: "Crate::async-stream:0.3.4"
+      curations:
+        comment: "Wrong detection of README and LICENSE files which are not included in final build anyway."
+        concluded_license: "MIT"
+    - id: "Crate::axum:0.5.17"
+      curations:
+        comment: "Wrong detection of README and LICENSE files which are not included in final build anyway."
+        concluded_license: "MIT"
+    - id: "Crate::tokio-util:0.7.7"
+      curations:
+        comment: "Wrong detection of README and LICENSE files which are not included in final build anyway."
+        concluded_license: "MIT"
+    - id: "Crate::tracing-attributes:0.1.23"
+      curations:
+        comment: "Wrong detection of README and LICENSE files which are not included in final build anyway."
+        concluded_license: "MIT"
+    - id: "Crate::windows:0.48.0"
+      curations:
+        comment: "Wrong detection of README, LICENSE files. Improper detection of of variables/traits/functions as License names. Windows crate is licensed under MIT or Apache-2.0. Additionally kantui/KAD do not target and do not compile for Windows-based systems."
+        concluded_license: "MIT OR Apache-2.0"
+    - id: "Crate::windows:0.48.0"
+      curations:
+        comment: "Wrong detection of README, LICENSE files. Improper detection of of variables/traits/functions as License names. Windows crate is licensed under MIT or Apache-2.0. Additionally kantui/KAD do not target and do not compile for Windows-based systems."
+        concluded_license: "MIT OR Apache-2.0"
+    - id: "Cargo::kantui:0.3.0"
+      curations:
+        comment: "Kantui and all of its sources are explicitly licensed under Apache-2.0 with appropriate SPDX identifiers"
+        concluded_license: "Apache-2.0"
+    - id: "Crate::ryu:1.0.13"
+      curations:
+        comment: "Ryu is dual-licensed under Apache-2.0 and BSL-1.0. Direct C-to-Rust translated files are licensed under Apache 2.0"
+        concluded_license: "Apache-2.0"
 license_choices:
   repository_license_choices:
-  - given: "GPL-2.0-or-later OR MIT"
-    choice: "MIT"
+    - given: "GPL-2.0-or-later OR MIT"
+      choice: "MIT"
+    - given: "MIT OR GPL-2.0-only"
+      choice: "MIT"
+    - given: "Apache-2.0 OR BSL-1.0"
+      choice: "Apache-2.0"

--- a/.ort.yml
+++ b/.ort.yml
@@ -1,1 +1,48 @@
 # Curation for OSS OCaaS findings. For reference, see : https://github.com/oss-review-toolkit/ort/blob/main/docs/config-file-ort-yml.md
+package_configurations:
+  - id: "Cargo::kantui:0.3.0"
+    vcs:
+      type: "Git"
+      url: "https://github.com/SoftwareDefinedVehicle/leda-utils-fork.git"
+      revision: "ea38c97ce8099ab327d24a8cbfb1fd0a33a43612"
+    license_finding_curations:
+    - path: "src/rust/kanto-tui/src/kanto_api.rs"
+      start_lines: "7"
+      line_count: 2
+      detected_license: "LicenseRef-scancode-biosl-4.0"
+      concluded_license: Apache-2.0
+      reason: INCORRECT
+      comment: "Kantui and all of its submodules are licensed under Apache-2.0"
+  - id: "Crate::rand_core:0.6.4"
+    source_artifact_url: "https://crates.io/api/v1/crates/rand_core/0.6.4/download"
+    license_finding_curations:
+    - path: "rand_core-0.6.4/LICENSE-APACHE"
+      start_lines: "7"
+      line_count: 181
+      detected_license: "ImageMagick"
+      concluded_license: "MIT OR Apache-2.0"
+      reason: INCORRECT
+      comment: "The rand_core crate is dual licensed under Apache-2.0 or MIT"
+  - id: "Crate::windows:0.48.0"
+    source_artifact_url: "https://crates.io/api/v1/crates/windows-sys/0.42.0/download"
+    path_excludes:
+    - pattern: "**/**"
+      reason: "OPTIONAL_COMPONENT_OF"
+      comment: "The distribution target architectures do not include windows and the crate is dual-licensed under Apache-2.0 or MIT"
+  - id: "Cargo::kantui:0.3.0"
+    vcs:
+      type: "Git"
+      url: "https://github.com/SoftwareDefinedVehicle/leda-utils-fork.git"
+      revision: "ea38c97ce8099ab327d24a8cbfb1fd0a33a43612"
+    license_finding_curations:
+    - path: "src/rust/kanto-tui/src/main.rs"
+      start_lines: "7"
+      line_count: 3
+      detected_license: "GPL-2.0-only"
+      concluded_license: Apache-2.0
+      reason: INCORRECT
+      comment: "Kantui and all of its submodules are licensed under Apache-2.0"
+license_choices:
+  repository_license_choices:
+  - given: "GPL-2.0-or-later OR MIT"
+    choice: "MIT"

--- a/.ort.yml
+++ b/.ort.yml
@@ -1,4 +1,12 @@
 # Curation for OSS OCaaS findings. For reference, see : https://github.com/oss-review-toolkit/ort/blob/main/docs/config-file-ort-yml.md
+excludes:
+  paths:
+  - pattern: "src/rust/kanto-auto-deployer/container-management/**"
+    reason: "BUILD_TOOL_OF"
+    comment: "Container management protobuffers are only used during build time and are licensed under Apache-2.0. No other parts of Container-managament are used"
+  - pattern: "src/rust/kanto-tui/container-management/**"
+    reason: "BUILD_TOOL_OF"
+    comment: "Container management protobuffers are only used during build time and are licensed under Apache-2.0. No other parts of Container-managament are used"
 package_configurations:
   - id: "Cargo::kantui:0.3.0"
     vcs:
@@ -42,6 +50,7 @@ package_configurations:
       concluded_license: Apache-2.0
       reason: INCORRECT
       comment: "Kantui and all of its submodules are licensed under Apache-2.0"
+    
 license_choices:
   repository_license_choices:
   - given: "GPL-2.0-or-later OR MIT"

--- a/.ort.yml
+++ b/.ort.yml
@@ -1,0 +1,1 @@
+# Curation for OSS OCaaS findings. For reference, see : https://github.com/oss-review-toolkit/ort/blob/main/docs/config-file-ort-yml.md

--- a/src/rust/kanto-tui/src/io.rs
+++ b/src/rust/kanto-tui/src/io.rs
@@ -1,3 +1,15 @@
+// ********************************************************************************
+// * Copyright (c) 2023 Contributors to the Eclipse Foundation
+// *
+// * See the NOTICE file(s) distributed with this work for additional
+// * information regarding copyright ownership.
+// *
+// * This program and the accompanying materials are made available under the
+// * terms of the Apache License 2.0 which is available at
+// * https://www.apache.org/licenses/LICENSE-2.0
+// *
+// * SPDX-License-Identifier: Apache-2.0
+// ********************************************************************************
 use super::{
     cm_rpc, kanto_api, kantui_config, try_best, KantoRequest, KantoResponse, RequestPriority,
     Result,

--- a/src/rust/kanto-tui/src/kanto_api.rs
+++ b/src/rust/kanto-tui/src/kanto_api.rs
@@ -1,4 +1,4 @@
-// /********************************************************************************
+// ********************************************************************************
 // * Copyright (c) 2022 Contributors to the Eclipse Foundation
 // *
 // * See the NOTICE file(s) distributed with this work for additional
@@ -9,7 +9,7 @@
 // * https://www.apache.org/licenses/LICENSE-2.0
 // *
 // * SPDX-License-Identifier: Apache-2.0
-// ********************************************************************************/
+// ********************************************************************************
 use anyhow::anyhow;
 #[cfg(unix)]
 use strip_ansi_escapes::strip;

--- a/src/rust/kanto-tui/src/kantui_config.rs
+++ b/src/rust/kanto-tui/src/kantui_config.rs
@@ -1,4 +1,4 @@
-// /********************************************************************************
+// ********************************************************************************
 // * Copyright (c) 2023 Contributors to the Eclipse Foundation
 // *
 // * See the NOTICE file(s) distributed with this work for additional
@@ -9,7 +9,7 @@
 // * https://www.apache.org/licenses/LICENSE-2.0
 // *
 // * SPDX-License-Identifier: Apache-2.0
-// ********************************************************************************/
+// ********************************************************************************
 use super::Result;
 use clap::Parser;
 use config::Config;

--- a/src/rust/kanto-tui/src/lib.rs
+++ b/src/rust/kanto-tui/src/lib.rs
@@ -1,4 +1,4 @@
-// /********************************************************************************
+// ********************************************************************************
 // * Copyright (c) 2022 Contributors to the Eclipse Foundation
 // *
 // * See the NOTICE file(s) distributed with this work for additional
@@ -9,7 +9,7 @@
 // * https://www.apache.org/licenses/LICENSE-2.0
 // *
 // * SPDX-License-Identifier: Apache-2.0
-// ********************************************************************************/
+// ********************************************************************************
 pub mod io;
 pub mod kanto_api;
 pub mod kantui_config;

--- a/src/rust/kanto-tui/src/main.rs
+++ b/src/rust/kanto-tui/src/main.rs
@@ -1,4 +1,4 @@
-// /********************************************************************************
+// ********************************************************************************
 // * Copyright (c) 2022 Contributors to the Eclipse Foundation
 // *
 // * See the NOTICE file(s) distributed with this work for additional
@@ -9,7 +9,7 @@
 // * https://www.apache.org/licenses/LICENSE-2.0
 // *
 // * SPDX-License-Identifier: Apache-2.0
-// ********************************************************************************/
+// ********************************************************************************
 use async_priority_channel::bounded;
 use kantui::{kantui_config, KantoRequest, KantoResponse, RequestPriority, Result};
 use nix::unistd::Uid;

--- a/src/rust/kanto-tui/src/ui/containers_table_view.rs
+++ b/src/rust/kanto-tui/src/ui/containers_table_view.rs
@@ -1,4 +1,4 @@
-// /********************************************************************************
+// ********************************************************************************
 // * Copyright (c) 2022 Contributors to the Eclipse Foundation
 // *
 // * See the NOTICE file(s) distributed with this work for additional
@@ -9,7 +9,7 @@
 // * https://www.apache.org/licenses/LICENSE-2.0
 // *
 // * SPDX-License-Identifier: Apache-2.0
-// ********************************************************************************/
+// ********************************************************************************
 use crate::kantui_config::{AppConfig, ALT_REPR, CTRL_REPR};
 use crate::{cm_types, try_best, Result};
 use cursive::align::HAlign;

--- a/src/rust/kanto-tui/src/ui/mod.rs
+++ b/src/rust/kanto-tui/src/ui/mod.rs
@@ -1,4 +1,4 @@
-// /********************************************************************************
+// ********************************************************************************
 // * Copyright (c) 2023 Contributors to the Eclipse Foundation
 // *
 // * See the NOTICE file(s) distributed with this work for additional
@@ -9,7 +9,7 @@
 // * https://www.apache.org/licenses/LICENSE-2.0
 // *
 // * SPDX-License-Identifier: Apache-2.0
-// ********************************************************************************/
+// ********************************************************************************
 use cursive::{traits::*, Cursive};
 use super::{
     kantui_config::AppConfig, try_best, KantoRequest, KantoResponse, RequestPriority, Result,


### PR DESCRIPTION
## Changes

- New github workflow for SDV repo only was set-up to do OCaaS scanning on PR/manual dispatch
- The .ort.yml file was properly curated to disable false positives
- Missing license header for kantui module added
- Kantui license-headers updated to be more ORT-friendly