### PR TITLE
Fix shell arithmetic for the cloudconnector check in sdv-health

### DIFF
--- a/src/sh/sdv-health
+++ b/src/sh/sdv-health
@@ -209,7 +209,7 @@ check_cloudconnector()
 			local SINCE
 			LAST_UPDATE=$(mosquitto_sub --quiet -h ${MOSQUITTO_HOST} -t 'edge/connection/remote/status' -C 1 -W 1 | jq .timestamp)
 			NOW=$(date +"%s")
-			DIFF=$(($NOW - $LAST_UPDATE))
+			DIFF=$((NOW - LAST_UPDATE))
 			SINCE=$(date -u -d @"$DIFF" +'%-Mm %-Ss')
 			printf -- "$TEXT_OK\t (connected since $SINCE)\n"
 		else

--- a/src/sh/sdv-health
+++ b/src/sh/sdv-health
@@ -209,7 +209,7 @@ check_cloudconnector()
 			local SINCE
 			LAST_UPDATE=$(mosquitto_sub --quiet -h ${MOSQUITTO_HOST} -t 'edge/connection/remote/status' -C 1 -W 1 | jq .timestamp)
 			NOW=$(date +"%s")
-			DIFF=$($NOW - $LAST_UPDATE)
+			DIFF=$(($NOW - $LAST_UPDATE))
 			SINCE=$(date -u -d @"$DIFF" +'%-Mm %-Ss')
 			printf -- "$TEXT_OK\t (connected since $SINCE)\n"
 		else
@@ -452,7 +452,7 @@ else
 fi
 
 # Static ip for mosquitto server. Containers will have access to host networks iff they run in host network mode.
-MOSQUITTO_HOST="127.0.0.1:1883"
+MOSQUITTO_HOST="127.0.0.1"
 
 printf -- "  * %-23s : %s\n" "Cloud Connector"         "$( check_cloudconnector )"
 printf -- "  * %-23s : ${COL_YELLOW}%s${COL_NC}\n" "Device ID:"  "$( check_cloudconnector_deviceid )"


### PR DESCRIPTION
Arithmetic in POSIX works with $(( <expression> )), otherwise it gets evaluated as an expression. This leads to the cloudconnector check always failing.