### PR TITLE
KAD to auto-disable itself when the VUM takes over to avoid state conflicts

### DIFF
--- a/.github/workflows/build-kanto-auto-deployer.yaml
+++ b/.github/workflows/build-kanto-auto-deployer.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Build binary
         run: |
           cd src/rust/kanto-auto-deployer
-          cargo build --release
+          cargo build --release --no-default-features --features=filewatcher
       - name: Package 
         run: |
           cp src/rust/kanto-auto-deployer/target/${{ matrix.target }}/release/kanto-auto-deployer . 

--- a/src/rust/kanto-auto-deployer/Cargo.lock
+++ b/src/rust/kanto-auto-deployer/Cargo.lock
@@ -672,6 +672,7 @@ dependencies = [
  "env_logger",
  "glob",
  "json-patch",
+ "lazy_static",
  "log",
  "notify",
  "prost",

--- a/src/rust/kanto-auto-deployer/Cargo.lock
+++ b/src/rust/kanto-auto-deployer/Cargo.lock
@@ -125,6 +125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bumpalo"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+
+[[package]]
 name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +195,22 @@ checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "crossbeam-channel"
@@ -283,6 +305,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "pin-project",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,42 +333,92 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.27"
+name = "futures"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
-name = "futures-sink"
-version = "0.3.27"
+name = "futures-executor"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
-
-[[package]]
-name = "futures-task"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
-
-[[package]]
-name = "futures-util"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.11",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -343,8 +428,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -556,6 +643,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
+name = "js-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "json-patch"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +675,8 @@ dependencies = [
  "log",
  "notify",
  "prost",
+ "rumqttc",
+ "rustls-native-certs",
  "serde",
  "serde_json",
  "tokio",
@@ -628,13 +726,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd550e73688e6d578f0ac2119e32b797a327631a42f9433e59d02e139c8df60d"
 
 [[package]]
-name = "log"
-version = "0.4.17"
+name = "lock_api"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
- "cfg-if",
+ "autocfg",
+ "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 
 [[package]]
 name = "matchit"
@@ -673,6 +778,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "notify"
 version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +819,12 @@ name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "os_str_bytes"
@@ -759,6 +879,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pollster"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da3b0203fd7ee5720aa0b5e790b591aa5d3f41c3ed2c34a3a393382198af2f7"
 
 [[package]]
 name = "ppv-lite86"
@@ -939,6 +1065,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "rumqttc"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "499b7ab08ffa5a722958b6ce1b7c0270bea30909f589d12c5ec3a051afe423fc"
+dependencies = [
+ "bytes",
+ "flume",
+ "futures",
+ "http",
+ "log",
+ "pollster",
+ "rustls-native-certs",
+ "rustls-pemfile 0.3.0",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,6 +1110,48 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5398f427a2b9246bfdfb86bc0ab11a15e49ccc7013d1d1346b8a26d4a366849d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 0.2.1",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+dependencies = [
+ "base64",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -965,6 +1167,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+dependencies = [
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c4437699b6d34972de58652c68b98cb5b53a4199ab126db8e20ec8ded29a721"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1015,6 +1265,21 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -1146,6 +1411,17 @@ dependencies = [
  "pin-project",
  "rand",
  "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -1325,6 +1601,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,6 +1637,80 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.11",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.11",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "web-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "which"

--- a/src/rust/kanto-auto-deployer/Cargo.lock
+++ b/src/rust/kanto-auto-deployer/Cargo.lock
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "kanto-auto-deployer"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/src/rust/kanto-auto-deployer/Cargo.toml
+++ b/src/rust/kanto-auto-deployer/Cargo.toml
@@ -21,12 +21,15 @@ serde_json = { version = "1.0.89", default-features = false}
 glob = "0.3.0"
 anyhow = "1.0.69"
 json-patch = {version  = "0.3.0", default-features = false}
-log = "0.4.0"
+log = "=0.4.18"
 env_logger = "0.9.3"
 notify = { version = "5.1.0", optional = true }
 clap = { version = "3.2.23", features = ["derive"] }
 enclose = { version = "1.1.8", optional = true }
 tokio-retry = "0.3.0"
+
+rumqttc = { version = "0.17.0"}
+rustls-native-certs="=0.6.0"
 
 [build-dependencies]
 tonic-build = "0.7.2"

--- a/src/rust/kanto-auto-deployer/Cargo.toml
+++ b/src/rust/kanto-auto-deployer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kanto-auto-deployer"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 description = "Automated deployment of Kanto Container Management Manifests"
 license = "Apache-2.0"
@@ -13,23 +13,22 @@ build = "build.rs"
 [dependencies]
 prost = "0.10.4"
 tokio = { version = "1.20.0", features = ["rt-multi-thread"] }
-tokio-stream = { version = "0.1.12", default-features = false}
+tokio-stream = { version = "0.1.12", default-features = false }
 tonic = { version = "0.7.2" }
-tower = { version = "0.4.13", default-features=false }
+tower = { version = "0.4.13", default-features = false }
 serde = { version = "1.0.147", default-features = false, features = ["derive"] }
-serde_json = { version = "1.0.89", default-features = false}
+serde_json = { version = "1.0.89", default-features = false }
 glob = "0.3.0"
 anyhow = "1.0.69"
-json-patch = {version  = "0.3.0", default-features = false}
+json-patch = { version = "0.3.0", default-features = false }
 log = "=0.4.18"
 env_logger = "0.9.3"
 notify = { version = "5.1.0", optional = true }
 clap = { version = "3.2.23", features = ["derive"] }
 enclose = { version = "1.1.8", optional = true }
 tokio-retry = "0.3.0"
-
-rumqttc = { version = "0.17.0"}
-rustls-native-certs="=0.6.0"
+rumqttc = { version = "0.17.0", optional = true }
+rustls-native-certs = { version = "=0.6.0", optional = true }
 
 [build-dependencies]
 tonic-build = "0.7.2"
@@ -39,8 +38,9 @@ name = "kanto-auto-deployer"
 path = "src/main.rs"
 
 [features]
-default = ["filewatcher"]
+default = ["filewatcher", "mqtt"]
 filewatcher = ["notify", "enclose"]
+mqtt = ["filewatcher", "rumqttc", "rustls-native-certs"]
 
 [profile.release]
 lto = true

--- a/src/rust/kanto-auto-deployer/Cargo.toml
+++ b/src/rust/kanto-auto-deployer/Cargo.toml
@@ -23,12 +23,15 @@ anyhow = "1.0.69"
 json-patch = { version = "0.3.0", default-features = false }
 log = "=0.4.18"
 env_logger = "0.9.3"
-notify = { version = "5.1.0", optional = true }
 clap = { version = "3.2.23", features = ["derive"] }
-enclose = { version = "1.1.8", optional = true }
 tokio-retry = "0.3.0"
+
+notify = { version = "5.1.0", optional = true }
+enclose = { version = "1.1.8", optional = true }
+
 rumqttc = { version = "0.17.0", optional = true }
 rustls-native-certs = { version = "=0.6.0", optional = true }
+lazy_static = { version = "1.4.0", optional = true}
 
 [build-dependencies]
 tonic-build = "0.7.2"
@@ -40,7 +43,7 @@ path = "src/main.rs"
 [features]
 default = ["filewatcher", "mqtt"]
 filewatcher = ["notify", "enclose"]
-mqtt = ["filewatcher", "rumqttc", "rustls-native-certs"]
+mqtt = ["filewatcher", "rumqttc", "rustls-native-certs", "lazy_static"]
 
 [profile.release]
 lto = true

--- a/src/rust/kanto-auto-deployer/src/main.rs
+++ b/src/rust/kanto-auto-deployer/src/main.rs
@@ -89,7 +89,7 @@ pub struct MQTTconfig {
     port: u16,
 
     /// Topic on which to subscribe for the desired state message feedback
-    #[clap(long = "mqtt-topic", default_value = "update/desiredstatefeedback")]
+    #[clap(long = "mqtt-topic", default_value = "deviceupdate/desiredstatefeedback")]
     topic: String,
 }
 

--- a/src/rust/kanto-auto-deployer/src/main.rs
+++ b/src/rust/kanto-auto-deployer/src/main.rs
@@ -350,7 +350,6 @@ async fn main() -> Result<()> {
         static THREAD_TERMINATE_FLAG: AtomicBool = AtomicBool::new(false);
         #[cfg(feature = "mqtt")]
         if cli.mqtt.enabled {
-            log::info!("MQTT for daemon mode enabled. Will auto-disable whenever VUM takes over.");
             thread::spawn({
                 let cli = cli.clone();
                 || mqtt_listener::mqtt_main(cli, &THREAD_TERMINATE_FLAG)

--- a/src/rust/kanto-auto-deployer/src/main.rs
+++ b/src/rust/kanto-auto-deployer/src/main.rs
@@ -83,8 +83,8 @@ pub struct MQTTconfig {
     #[clap(long = "mqtt-broker-port", default_value_t = 1883)]
     port: u16,
 
-    /// Topic on which to subscribe for the desired state message
-    #[clap(long = "mqtt-topic", default_value = "test/topic")]
+    /// Topic on which to subscribe for the desired state message feedback
+    #[clap(long = "mqtt-topic", default_value = "update/desiredstatefeedback")]
     topic: String,
 }
 

--- a/src/rust/kanto-auto-deployer/src/main.rs
+++ b/src/rust/kanto-auto-deployer/src/main.rs
@@ -89,7 +89,10 @@ pub struct MQTTconfig {
     port: u16,
 
     /// Topic on which to subscribe for the desired state message feedback
-    #[clap(long = "mqtt-topic", default_value = "containersupdate/desiredstatefeedback")]
+    #[clap(
+        long = "mqtt-topic",
+        default_value = "containersupdate/desiredstatefeedback"
+    )]
     topic: String,
 }
 

--- a/src/rust/kanto-auto-deployer/src/main.rs
+++ b/src/rust/kanto-auto-deployer/src/main.rs
@@ -89,7 +89,7 @@ pub struct MQTTconfig {
     port: u16,
 
     /// Topic on which to subscribe for the desired state message feedback
-    #[clap(long = "mqtt-topic", default_value = "deviceupdate/desiredstatefeedback")]
+    #[clap(long = "mqtt-topic", default_value = "containersupdate/desiredstatefeedback")]
     topic: String,
 }
 

--- a/src/rust/kanto-auto-deployer/src/main.rs
+++ b/src/rust/kanto-auto-deployer/src/main.rs
@@ -24,6 +24,8 @@ use tonic::transport::{Endpoint, Uri};
 use tower::service_fn;
 
 pub mod manifest_parser;
+
+#[cfg(feature = "mqtt")]
 pub mod mqtt_listener;
 pub mod containers {
     //This is a hack because tonic has an issue with deeply nested protobufs
@@ -61,10 +63,12 @@ pub struct CliArgs {
     #[cfg(feature = "filewatcher")]
     daemon: bool,
 
+    #[cfg(feature = "mqtt")]
     #[clap(flatten)]
     mqtt: MQTTconfig,
 }
 
+#[cfg(feature = "mqtt")]
 #[derive(Debug, Args)]
 pub struct MQTTconfig {
     /// Hostname/IP to the MQTT broker where the desired state message would be posted
@@ -342,6 +346,7 @@ async fn main() -> Result<()> {
     #[cfg(feature = "filewatcher")]
     if cli.daemon {
         static THREAD_TERMINATE_FLAG: AtomicBool = AtomicBool::new(false);
+        #[cfg(feature = "mqtt")]
         thread::spawn({
             let cli = cli.clone();
             || mqtt_listener::mqtt_main(cli, &THREAD_TERMINATE_FLAG)

--- a/src/rust/kanto-auto-deployer/src/main.rs
+++ b/src/rust/kanto-auto-deployer/src/main.rs
@@ -11,19 +11,22 @@
 // * SPDX-License-Identifier: Apache-2.0
 // ********************************************************************************
 use glob::glob;
+use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::{fs, thread};
 
 use anyhow::Result;
-use clap::{Args, Parser};
+use clap::Parser;
 use std::sync::atomic::AtomicBool;
 use tokio::net::UnixStream;
 use tokio_retry::{strategy, RetryIf};
 use tonic::transport::{Endpoint, Uri};
 use tower::service_fn;
 
-pub mod manifest_parser;
+#[cfg(feature = "mqtt")]
+use clap::Args;
+#[cfg(feature = "mqtt")]
+use std::thread;
 
 #[cfg(feature = "mqtt")]
 pub mod mqtt_listener;
@@ -36,6 +39,8 @@ pub mod containers {
 pub mod fs_watcher;
 #[cfg(feature = "filewatcher")]
 use fs_watcher::is_filetype;
+
+pub mod manifest_parser;
 
 use containers::github::com::eclipse_kanto::container_management::containerm::api::services::containers as kanto;
 use containers::github::com::eclipse_kanto::container_management::containerm::api::types::containers as kanto_cnt;

--- a/src/rust/kanto-auto-deployer/src/mqtt_listener.rs
+++ b/src/rust/kanto-auto-deployer/src/mqtt_listener.rs
@@ -37,7 +37,7 @@ lazy_static! {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-struct VUMmsg<T> {
+struct VUMEnvelope<T> {
     #[serde(alias = "activityId")]
     activity_id: String,
     timestamp: u64,
@@ -45,12 +45,12 @@ struct VUMmsg<T> {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-struct FeedBackPayload {
+struct FeedbackPayload {
     status: String,
     // We don't care about the rest of the fields
 }
 
-type FeedBackMsg = VUMmsg<FeedBackPayload>;
+type FeedbackMsg = VUMEnvelope<FeedbackPayload>;
 
 fn kad_enabled(lock: &Path) -> bool {
     lock.exists() && lock.is_file()
@@ -82,7 +82,7 @@ fn handle_mqtt_payload(
     thread_terminate_flag: &AtomicBool,
 ) -> Result<()> {
     // Listen when VUM starts "identifying" what actions it should take.
-    let terminate_flag_mqtt = serde_json::from_slice::<FeedBackMsg>(payload)?
+    let terminate_flag_mqtt = serde_json::from_slice::<FeedbackMsg>(payload)?
         .payload
         .status
         .eq(VUM_STATUS_IDENTIFYING);

--- a/src/rust/kanto-auto-deployer/src/mqtt_listener.rs
+++ b/src/rust/kanto-auto-deployer/src/mqtt_listener.rs
@@ -30,9 +30,9 @@ fn kad_enabled(lock: &PathBuf) -> bool {
 fn disable_kad(lock_path: &PathBuf) -> Result<()> {
     let mut disabled_lock_path = lock_path.clone();
 
-    if !lock_path.is_file() {
+    if !kad_enabled(lock_path) {
         return Err(anyhow!(
-            "{:?} is not a regular file or does not exist",
+            "Lock {:?} is not a regular file or does not exist",
             lock_path
         ));
     }

--- a/src/rust/kanto-auto-deployer/src/mqtt_listener.rs
+++ b/src/rust/kanto-auto-deployer/src/mqtt_listener.rs
@@ -98,8 +98,8 @@ pub fn mqtt_main(cli_config: Arc<CliArgs>, thread_terminate_flag: &AtomicBool) -
             "The lock at {:?} does not exist, but KAD was started with the MQTT client \
         option. MQTT listener will not be started, but KAD will still run in daemon mode. \
         If running as a system service this might mean KAD has previously seen the desired \
-        state MQTT message and has auto-disabled itself to avoid conflicts with CUA and might \
-        lead to unexpected behavior.",
+        state MQTT message and has auto-disabled itself to avoid conflicts with CUA and using \
+        it might lead to unexpected behavior.",
             *LOCK_PATH
         );
         return Ok(());

--- a/src/rust/kanto-auto-deployer/src/mqtt_listener.rs
+++ b/src/rust/kanto-auto-deployer/src/mqtt_listener.rs
@@ -23,8 +23,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 static SERVICE_ID: &str = "kanto_auto_deployer";
-// We let VUM take over when it starts identifying what needs to be done for an update.
-static VUM_STATUS_IDENTIFYING: &str = "IDENTIFYING";
+// We let CUA take over when it has identified what it should do
+static VUM_STATUS_IDENTIFIED: &str = "IDENTIFIED";
 static RECONNECT_TIMEOUT: u64 = 2;
 
 lazy_static! {
@@ -85,7 +85,7 @@ fn handle_mqtt_payload(
     let terminate_flag_mqtt = serde_json::from_slice::<FeedbackMsg>(payload)?
         .payload
         .status
-        .eq(VUM_STATUS_IDENTIFYING);
+        .eq(VUM_STATUS_IDENTIFIED);
 
     if !terminate_flag_mqtt {
         return Err(anyhow!(

--- a/src/rust/kanto-auto-deployer/src/mqtt_listener.rs
+++ b/src/rust/kanto-auto-deployer/src/mqtt_listener.rs
@@ -1,0 +1,74 @@
+use anyhow::{anyhow, Result};
+use rumqttc::{self, Client, Event::Incoming, MqttOptions, Packet::Publish, QoS};
+use serde_json::{self, Value};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use std::time::Duration;
+
+static SERVICE_ID: &str = "KAD";
+static TOPIC: &str = "kanto-auto-deployer/state";
+static HOST: &str = "localhost";
+static PORT: u16 = 1883;
+static TERMINATE_KEY_JSON: &str = "terminate";
+static RECONNECT_TIMEOUT: u64 = 2;
+
+fn handle_mqtt_payload(payload: &[u8], thread_terminate_flag: &AtomicBool) -> Result<()> {
+    // We don't care about non-json messages
+    let terminate_flag_mqtt = serde_json::from_slice::<HashMap<String, Value>>(payload)?
+        .get(TERMINATE_KEY_JSON)
+        .ok_or_else(|| {
+            anyhow!("MQTT message is valid json, but does not contain key {TERMINATE_KEY_JSON}")
+        })?
+        .as_bool()
+        .ok_or_else(|| anyhow!("Expected boolean type for value for key {TERMINATE_KEY_JSON}"))?;
+
+    // Only if the termination request is received, update the atomic flag
+    if terminate_flag_mqtt {
+        thread_terminate_flag.store(true, Ordering::Relaxed);
+    }
+
+    Ok(())
+}
+
+fn try_mqtt_reconnect(timeout: &mut Duration, client: &mut Client, delta: Duration) {
+    println!(
+        "MQTT connection lost, trying to re-subscribe in {} s",
+        timeout.as_secs()
+    );
+    if let Err(e) = client.try_subscribe(TOPIC, QoS::ExactlyOnce) {
+        println!("Failed to resubscribe: {e}");
+        *timeout += delta;
+        std::thread::sleep(*timeout);
+    } else {
+        // Success, reset timeout
+        *timeout = delta;
+    }
+}
+
+pub fn mqtt_main(thread_terminate_flag: &AtomicBool) -> Result<()> {
+    let mut mqttoptions = MqttOptions::new(SERVICE_ID, HOST, PORT);
+    mqttoptions.set_keep_alive(Duration::from_secs(5));
+
+    let delta = Duration::from_secs(RECONNECT_TIMEOUT);
+    let mut timeout = delta;
+
+    let (mut client, mut connection) = Client::new(mqttoptions.clone(), 10);
+    client.subscribe(TOPIC, QoS::ExactlyOnce)?;
+
+    for notification in connection.iter() {
+        // We only care about incoming messages
+        if let Ok(msg) = notification {
+            if let Incoming(Publish(pub_msg)) = msg {
+                let _r = handle_mqtt_payload(&pub_msg.payload, thread_terminate_flag);
+                if let Err(e) = _r {
+                    log::debug!("MQTT message parsing error: {e}")
+                }
+            }
+        } else {
+            try_mqtt_reconnect(&mut timeout, &mut client, delta);
+        }
+    }
+
+    Ok(())
+}

--- a/src/rust/kanto-auto-deployer/src/mqtt_listener.rs
+++ b/src/rust/kanto-auto-deployer/src/mqtt_listener.rs
@@ -3,16 +3,56 @@ use anyhow::{anyhow, Result};
 use rumqttc::{self, Client, Event::Incoming, MqttOptions, Packet::Publish, QoS};
 use serde_json::{self, Value};
 use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use std::time::Duration;
 
-static SERVICE_ID: &str = "kanto-auto-deployer";
+static SERVICE_ID: &str = "kanto_auto_deployer";
+static LOCK_NAME: &str = "KAD.enabled";
 static TERMINATE_KEY_JSON: &str = "terminate";
 static RECONNECT_TIMEOUT: u64 = 2;
 
-fn handle_mqtt_payload(payload: &[u8], thread_terminate_flag: &AtomicBool) -> Result<()> {
+fn obtain_lock_path(cli_config: &CliArgs) -> Result<PathBuf> {
+    let manifests_dir = fs::canonicalize(cli_config.manifests_path.clone())?;
+    let lock_full = manifests_dir.join(LOCK_NAME);
+    if lock_full.is_file() {
+        return Ok(lock_full);
+    } else {
+        return Err(anyhow!(
+            "Path {:?} does not exist or is not a file!",
+            lock_full
+        ));
+    }
+}
+
+fn disable_kad(lock_path: &PathBuf) -> Result<()> {
+    let mut disabled_lock_path = lock_path.clone();
+
+    if !lock_path.is_file() {
+        return Err(anyhow!(
+            "{:?} is not a regular file or does not exist",
+            lock_path
+        ));
+    }
+    if !disabled_lock_path.set_extension("disabled") {
+        return Err(anyhow!(
+            "Could not change extension of {:?} to *.disabled",
+            lock_path
+        ));
+    }
+    fs::rename(lock_path, disabled_lock_path)?;
+
+    Ok(())
+}
+
+fn handle_mqtt_payload(
+    payload: &[u8],
+    lock_path: &PathBuf,
+    thread_terminate_flag: &AtomicBool,
+) -> Result<()> {
     // We don't care about non-json messages
     let terminate_flag_mqtt = serde_json::from_slice::<HashMap<String, Value>>(payload)?
         .get(TERMINATE_KEY_JSON)
@@ -24,6 +64,9 @@ fn handle_mqtt_payload(payload: &[u8], thread_terminate_flag: &AtomicBool) -> Re
 
     // Only if an actual termination request is received, update the atomic flag
     if terminate_flag_mqtt {
+        if let Err(e) = disable_kad(&lock_path) {
+            log::error!("Could not set KAD lock to disabled: {e}")
+        }
         thread_terminate_flag.store(true, Ordering::Relaxed);
     }
 
@@ -50,7 +93,19 @@ pub fn mqtt_main(cli_config: Arc<CliArgs>, thread_terminate_flag: &AtomicBool) -
         "Trying to start MQTT connection with options {:?}",
         &cli_config.mqtt
     );
-    
+
+    let lock_path;
+    match obtain_lock_path(&cli_config) {
+        Ok(lock) => {
+            lock_path = lock;
+        }
+        Err(e) => {
+            log::error!("Could not obtain {LOCK_NAME}. Will continue running in daemon mode \
+            but will not start the MQTT listener. Err: {e}");
+            return Ok(());
+        }
+    }
+
     let mut mqttoptions = MqttOptions::new(SERVICE_ID, &cli_config.mqtt.ip, cli_config.mqtt.port);
     mqttoptions.set_keep_alive(Duration::from_secs(5));
     let delta = Duration::from_secs(RECONNECT_TIMEOUT);
@@ -63,7 +118,7 @@ pub fn mqtt_main(cli_config: Arc<CliArgs>, thread_terminate_flag: &AtomicBool) -
         // We only care about incoming messages
         if let Ok(msg) = notification {
             if let Incoming(Publish(pub_msg)) = msg {
-                let _r = handle_mqtt_payload(&pub_msg.payload, thread_terminate_flag);
+                let _r = handle_mqtt_payload(&pub_msg.payload, &lock_path, thread_terminate_flag);
                 if let Err(e) = _r {
                     log::debug!("MQTT message parsing error: {e}")
                 }

--- a/src/rust/kanto-auto-deployer/src/mqtt_listener.rs
+++ b/src/rust/kanto-auto-deployer/src/mqtt_listener.rs
@@ -1,3 +1,15 @@
+// ********************************************************************************
+// * Copyright (c) 2023 Contributors to the Eclipse Foundation
+// *
+// * See the NOTICE file(s) distributed with this work for additional
+// * information regarding copyright ownership.
+// *
+// * This program and the accompanying materials are made available under the
+// * terms of the Apache License 2.0 which is available at
+// * https://www.apache.org/licenses/LICENSE-2.0
+// *
+// * SPDX-License-Identifier: Apache-2.0
+// ********************************************************************************
 use crate::CliArgs;
 use anyhow::{anyhow, Result};
 use lazy_static::lazy_static;

--- a/src/rust/kanto-auto-deployer/src/mqtt_listener.rs
+++ b/src/rust/kanto-auto-deployer/src/mqtt_listener.rs
@@ -89,7 +89,7 @@ fn handle_mqtt_payload(
 
     if !terminate_flag_mqtt {
         return Err(anyhow!(
-            "Expected status:\"{VUM_STATUS_IDENTIFYING}\" for status"
+            "Expected status:\"{VUM_STATUS_IDENTIFIED}\" for status"
         ));
     }
     disable_kad(lock_path)?;

--- a/src/rust/kanto-auto-deployer/src/mqtt_listener.rs
+++ b/src/rust/kanto-auto-deployer/src/mqtt_listener.rs
@@ -22,7 +22,7 @@ fn handle_mqtt_payload(payload: &[u8], thread_terminate_flag: &AtomicBool) -> Re
         .as_bool()
         .ok_or_else(|| anyhow!("Expected boolean type for value for key {TERMINATE_KEY_JSON}"))?;
 
-    // Only if the termination request is received, update the atomic flag
+    // Only if an actual termination request is received, update the atomic flag
     if terminate_flag_mqtt {
         thread_terminate_flag.store(true, Ordering::Relaxed);
     }
@@ -46,10 +46,13 @@ fn try_mqtt_reconnect(timeout: &mut Duration, client: &mut Client, topic: &str, 
 }
 
 pub fn mqtt_main(cli_config: Arc<CliArgs>, thread_terminate_flag: &AtomicBool) -> Result<()> {
+    log::debug!(
+        "Trying to start MQTT connection with options {:?}",
+        &cli_config.mqtt
+    );
+    
     let mut mqttoptions = MqttOptions::new(SERVICE_ID, &cli_config.mqtt.ip, cli_config.mqtt.port);
-    log::debug!("Trying to start MQTT connection with options {:?}", &cli_config.mqtt);
     mqttoptions.set_keep_alive(Duration::from_secs(5));
-
     let delta = Duration::from_secs(RECONNECT_TIMEOUT);
     let mut timeout = delta;
 


### PR DESCRIPTION
## Issue

KAD conflicts (overlaps) with VUM/CUA (Kanto update manager). We would like KAD to auto-disable itself when the container-update-agent (CUA) starts publishing to the `containersupdate/desiredstatefeedback` topic that it's identifying what actions it should take. 
Ideally, once disabled the KAD service will stay disabled after reboots/updates as the UM is fully managing the device.

## Solution

We add a new module  `mqtt_listener` to KAD under a compile-time feature flag called "mqtt". This module starts a lightweight MQTT client in a separate thread that subscribes to the MQTT broker and listens on the `containersupdate/desiredstatefeedback` topic for messages from (UM) with status "**IDENTIFIED**".  

Additionally the existence of a lock-file (default path: `/var/lib/kanto-auto-deployer/KAD.enabled`) is used as persistent marker that KAD has previously seen this message.

When the message with status "IDENTIFIED" is received:
- MQTT thread changes the extension of the lock to `.disabled`
- Sends a signal to the daemon (filewatcher) thread to shut down
- MQTT thread exits 
- KAD exits with ERRNO=0 (success)

The systemd unit for KAD (example [here](ConditionPathExists=/data/var/lib/kanto-auto-deployer/KAD.enabled
)) is expanded with:
```
[Unit]
...
ConditionPathExists=/var/lib/kanto-auto-deployer/KAD.enabled
```
Now systemd will always skip the KAD unit on subsequent restarts if the lock-file does not exist.

On sysVinit systems this can be checked in the runlevel-script in a similar fashion.

## Testing:

1) Build QEMUx86-64 from `kad-mqtt-poc` of https://github.com/SoftwareDefinedVehicle/leda-distro-fork

2) Run image

3)  Create a mock_desiredstatefeedback.json message (from UM tests):
```json
{
    "activityId": "123e4567-e89b-12d3-a456-426614174000",
    "timestamp": 123456789,
    "payload": {
        "status": "INDENTIFIED",
        "message": "This is a mock desired state feedback message",
        "actions": []
    }
}
```

4) `mosquitto_pub -t containersupdate/desiredstatefeedback -f mock_desiredstatefeedback.json `

5) Check logs: `journalctl -u kanto-auto-deployer`. Expected:

```log
root@qemux86-64:~# journalctl -u kanto-auto-deployer
Jun 28 11:38:30 qemux86-64 systemd[1]: Started Kanto Auto Deployer.
Jun 28 11:38:30 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:30Z INFO  kanto_auto_deployer] Running initial deployment of "/data/var/containers/manifests"
Jun 28 11:38:30 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:30Z INFO  kanto_auto_deployer] Reading manifests from [/data/var/containers/manifests]
Jun 28 11:38:30 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:30Z ERROR kanto_auto_deployer] An error occurred when connecting to socket: Os { code: 2, kind: NotFound, message: "No such file or directory" }
Jun 28 11:38:30 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:30Z ERROR kanto_auto_deployer] An error occurred when connecting to socket: Os { code: 2, kind: NotFound, message: "No such file or directory" }
Jun 28 11:38:30 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:30Z ERROR kanto_auto_deployer] An error occurred when connecting to socket: Os { code: 2, kind: NotFound, message: "No such file or directory" }
Jun 28 11:38:30 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:30Z ERROR kanto_auto_deployer] An error occurred when connecting to socket: Os { code: 2, kind: NotFound, message: "No such file or directory" }
Jun 28 11:38:31 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:31Z ERROR kanto_auto_deployer] An error occurred when connecting to socket: Os { code: 2, kind: NotFound, message: "No such file or directory" }
Jun 28 11:38:31 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:31Z ERROR kanto_auto_deployer] An error occurred when connecting to socket: Os { code: 2, kind: NotFound, message: "No such file or directory" }
Jun 28 11:38:32 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:32Z ERROR kanto_auto_deployer] An error occurred when connecting to socket: Os { code: 2, kind: NotFound, message: "No such file or directory" }
Jun 28 11:38:33 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:33Z WARN  kanto_auto_deployer::manifest_parser] Failed to load manifest directly. Will attempt auto-conversion from init-dir format.
Jun 28 11:38:33 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:33Z INFO  kanto_auto_deployer] Already exists [cloudconnector]
Jun 28 11:38:33 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:33Z WARN  kanto_auto_deployer::manifest_parser] Failed to load manifest directly. Will attempt auto-conversion from init-dir format.
Jun 28 11:38:33 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:33Z INFO  kanto_auto_deployer] Already exists [databroker]
Jun 28 11:38:33 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:33Z WARN  kanto_auto_deployer::manifest_parser] Failed to load manifest directly. Will attempt auto-conversion from init-dir format.
Jun 28 11:38:33 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:33Z INFO  kanto_auto_deployer] Already exists [feedercan]
Jun 28 11:38:33 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:33Z WARN  kanto_auto_deployer::manifest_parser] Failed to load manifest directly. Will attempt auto-conversion from init-dir format.
Jun 28 11:38:33 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:33Z INFO  kanto_auto_deployer] Already exists [hvacservice-example]
Jun 28 11:38:33 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:33Z WARN  kanto_auto_deployer::manifest_parser] Failed to load manifest directly. Will attempt auto-conversion from init-dir format.
Jun 28 11:38:33 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:33Z INFO  kanto_auto_deployer] Already exists [seatservice-example]
Jun 28 11:38:33 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:33Z WARN  kanto_auto_deployer::manifest_parser] Failed to load manifest directly. Will attempt auto-conversion from init-dir format.
Jun 28 11:38:33 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:33Z INFO  kanto_auto_deployer] Already exists [sua]
Jun 28 11:38:33 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:33Z WARN  kanto_auto_deployer::manifest_parser] Failed to load manifest directly. Will attempt auto-conversion from init-dir format.
Jun 28 11:38:33 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:33Z INFO  kanto_auto_deployer] Already exists [vum]
Jun 28 11:38:33 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:33Z INFO  kanto_auto_deployer] Running in daemon mode. Continuously monitoring "/data/var/containers/manifests"
Jun 28 11:38:33 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:38:33Z INFO  kanto_auto_deployer::mqtt_listener] MQTT for daemon mode enabled. Will auto-disable whenever VUM takes over.
Jun 28 11:40:58 qemux86-64 kanto-auto-deployer[500]: [2023-06-28T11:40:58Z WARN  kanto_auto_deployer::fs_watcher] Getting terminated from MQTT!
Jun 28 11:40:58 qemux86-64 systemd[1]: kanto-auto-deployer.service: Deactivated successfully.
Jun 28 11:41:28 qemux86-64 systemd[1]: Kanto Auto Deployer was skipped because of a failed condition check (ConditionPathExists=/data/var/lib/kanto-auto-deployer/KAD.enabled).
```

## Other

- Do not build the MQTT listener module in .deb releases, since this is for cases when KAD is ran as system service.
- The path of the lock can be set during compilation time by exporting the variable `KAD_LOCK_PATH=/PATH/TO/LOCK/FILE` to the environment and then running the `cargo build`
- Version has been bumped to 0.3.0 
- meta-leda testing setup: [Diff with eclipse-leda/meta-leda](https://github.com/eclipse-leda/meta-leda/compare/main...SoftwareDefinedVehicle:meta-leda-fork:kad-mqtt-poc)
- Leda-distro testing setup: [Diff with eclipse-leda/leda-distro](https://github.com/eclipse-leda/leda-distro/compare/main...SoftwareDefinedVehicle:leda-distro-fork:kad-mqtt-poc)
