### PR TITLE
Convert .deb packages to .rpm

### DIFF
--- a/.github/workflows/build-kanto-auto-deployer.yaml
+++ b/.github/workflows/build-kanto-auto-deployer.yaml
@@ -107,7 +107,7 @@ jobs:
           sudo find ./ -maxdepth 1 -name "*.deb" -exec alien --scripts --to-rpm {} \;
       - uses: actions/upload-artifact@v3
         with:
-          name: kanto-auto-deployer-debian
+          name: kanto-auto-deployer-packages
           path: |
             ./*.deb
             ./*.rpm

--- a/.github/workflows/build-kanto-auto-deployer.yaml
+++ b/.github/workflows/build-kanto-auto-deployer.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+          sudo apt-get install -y protobuf-compiler alien
       - name: Install cross-compilation tools
         uses: taiki-e/setup-cross-toolchain-action@v1
         with:
@@ -102,8 +102,12 @@ jobs:
           arch: '${{ env.package_arch }}'
           depends: 'libc6'
           desc: 'Automated container deployment based on JSON descriptors for Eclipse Kanto Container Management'
+      - name: Convert deb to rpm
+        run: |
+          sudo find ./ -maxdepth 1 -name "*.deb" -exec alien --scripts --to-rpm {} \;
       - uses: actions/upload-artifact@v3
         with:
           name: kanto-auto-deployer-debian
-          path: 
+          path: |
             ./*.deb
+            ./*.rpm

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+          sudo apt-get install -y protobuf-compiler alien
       - name: Install cross-compilation tools
         uses: taiki-e/setup-cross-toolchain-action@v1
         with:
@@ -105,8 +105,12 @@ jobs:
           arch: '${{ env.package_arch }}'
           depends: 'libc6'
           desc: 'Text user interface (cli) for Eclipse Kanto Container Management'
+      - name: Convert deb to rpm
+        run: |
+          sudo find ./ -maxdepth 1 -name "*.deb" -exec alien --scripts --to-rpm {} \;
       - uses: actions/upload-artifact@v3
         with:
-          name: kantui-debian
+          name: kantui-packages
           path: 
             ./*.deb
+            ./*.rpm

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -111,6 +111,6 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: kantui-packages
-          path: 
+          path: |
             ./*.deb
             ./*.rpm

--- a/.github/workflows/build-leda-utils.yaml
+++ b/.github/workflows/build-leda-utils.yaml
@@ -31,6 +31,10 @@ jobs:
         with:
           submodules: 'recursive'
           fetch-depth: 0
+      - name: Install Tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y alien
       - name: Run ShellCheck
         uses: azohra/shell-linter@latest
         with:
@@ -84,9 +88,13 @@ jobs:
           version: '${{ env.package_version }}'
           arch: 'all'
           desc: 'Shell utilities for Eclipse Leda (Software-Defined Vehicle)'
+      - name: Convert deb to rpm
+        run: |
+          sudo find ./ -maxdepth 1 -name "*.deb" -exec alien --scripts --to-rpm {} \;
       - uses: actions/upload-artifact@v3
         with:
           name: leda-utils-debian
-          path: 
+          path: |
             ./*.deb
+            ./*.rpm
 

--- a/.github/workflows/build-leda-utils.yaml
+++ b/.github/workflows/build-leda-utils.yaml
@@ -93,7 +93,7 @@ jobs:
           sudo find ./ -maxdepth 1 -name "*.deb" -exec alien --scripts --to-rpm {} \;
       - uses: actions/upload-artifact@v3
         with:
-          name: leda-utils-debian
+          name: leda-utils-packages
           path: |
             ./*.deb
             ./*.rpm

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,9 +40,14 @@ jobs:
         with:
           fail_on_unmatched_files: true
           files: |
-            ${{steps.download.outputs.download-path}}/kantui-debian/eclipse-leda-kantui_*_amd64.deb
-            ${{steps.download.outputs.download-path}}/kantui-debian/eclipse-leda-kantui_*_arm64.deb
-            ${{steps.download.outputs.download-path}}/kanto-auto-deployer-debian/eclipse-leda-kanto-auto-deployer_*_amd64.deb
-            ${{steps.download.outputs.download-path}}/kanto-auto-deployer-debian/eclipse-leda-kanto-auto-deployer_*_arm64.deb
-            ${{steps.download.outputs.download-path}}/leda-utils-debian/eclipse-leda-utils*.deb
-
+            ${{steps.download.outputs.download-path}}/kantui-packages/eclipse-leda-kantui_*_amd64.deb
+            ${{steps.download.outputs.download-path}}/kantui-packages/eclipse-leda-kantui_*_arm64.deb
+            ${{steps.download.outputs.download-path}}/kanto-auto-deployer-packages/eclipse-leda-kanto-auto-deployer_*_amd64.deb
+            ${{steps.download.outputs.download-path}}/kanto-auto-deployer-packages/eclipse-leda-kanto-auto-deployer_*_arm64.deb
+            ${{steps.download.outputs.download-path}}/leda-utils-packages/eclipse-leda-utils*.deb
+            ${{steps.download.outputs.download-path}}/kantui-packages/eclipse-leda-kantui*.x86_64.rpm
+            ${{steps.download.outputs.download-path}}/kantui-packages/eclipse-leda-kantui*.arm64.rpm
+            ${{steps.download.outputs.download-path}}/kanto-auto-deployer-packages/eclipse-leda-kanto-auto-deployer*.x86_64.rpm
+            ${{steps.download.outputs.download-path}}/kanto-auto-deployer-packages/eclipse-leda-kanto-auto-deployer*.arm64.rpm
+            ${{steps.download.outputs.download-path}}/leda-utils-packages/eclipse-leda-utils*.noarch.rpm
+            


### PR DESCRIPTION
We would like to make it easy for users to install leda-utils on rpm-based distributions. That is why in this PR the workflows were modified to convert the .deb packages to .rpm using the `alien` tool.
