### PR TITLE
Moving vum to service

### DIFF
--- a/src/sh/sdv-health
+++ b/src/sh/sdv-health
@@ -31,14 +31,14 @@ SDV_CAN="can0"
 SDV_CAN_RADAR=""
 
 # Default list of monitored Systemd Services
-SDV_SERVICES="containerd rauc container-management"
+SDV_SERVICES="containerd rauc container-management update-manager"
 
 # Default list of optional Systemd Services
 #SDV_SERVICES_OPT="vehicle-api mosquitto"
 SDV_SERVICES_OPT="sshd.socket systemd-networkd systemd-timesyncd"
 
 # Default list of requred SDV Docker containers
-KANTO_CM_CONTAINERS="cloudconnector databroker vum sua "
+KANTO_CM_CONTAINERS="cloudconnector databroker sua "
 KANTO_CM_CONTAINERS_OPT="seatservice-example hvacservice-example feedercan feedergps otelcol-sdv-exporter otelcol-sdv-agent "
 # Change internet connectivity check host
 SDV_PING_HOST="1.1.1.1"


### PR DESCRIPTION
### VUM to service
-  As vum is no longer a container, it will be checked of presence as a service