### PR TITLE
Async deployment of manifests with kad

### DIFF
--- a/src/rust/kanto-auto-deployer/Cargo.lock
+++ b/src/rust/kanto-auto-deployer/Cargo.lock
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -349,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -359,15 +359,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -376,15 +376,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -393,21 +393,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -670,6 +670,7 @@ dependencies = [
  "clap",
  "enclose",
  "env_logger",
+ "futures",
  "glob",
  "json-patch",
  "lazy_static",
@@ -929,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.54"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]

--- a/src/rust/kanto-auto-deployer/Cargo.toml
+++ b/src/rust/kanto-auto-deployer/Cargo.toml
@@ -12,7 +12,7 @@ build = "build.rs"
 
 [dependencies]
 prost = "0.10.4"
-tokio = { version = "1.20.0", features = ["rt-multi-thread"] }
+tokio = { version = "1.20.0", features = ["rt-multi-thread", "fs"] }
 tokio-stream = { version = "0.1.12", default-features = false }
 tonic = { version = "0.7.2" }
 tower = { version = "0.4.13", default-features = false }
@@ -32,6 +32,7 @@ enclose = { version = "1.1.8", optional = true }
 rumqttc = { version = "0.17.0", optional = true }
 rustls-native-certs = { version = "=0.6.0", optional = true }
 lazy_static = { version = "1.4.0", optional = true}
+futures = "0.3.29"
 
 [build-dependencies]
 tonic-build = "0.7.2"

--- a/src/rust/kanto-auto-deployer/src/main.rs
+++ b/src/rust/kanto-auto-deployer/src/main.rs
@@ -363,7 +363,7 @@ async fn main() -> Result<()> {
 
     // One-shot deployment of all manifests in directory
     if let Err(e) = deploy_directory(&manifests_path, &socket_path, retry_times).await {
-        log::error!("Failed to deploy directory: {e}.")
+        log::error!("Failed to deploy directory: {e}")
     }
 
     #[cfg(feature = "filewatcher")]

--- a/src/rust/kanto-auto-deployer/src/manifest_parser.rs
+++ b/src/rust/kanto-auto-deployer/src/manifest_parser.rs
@@ -125,7 +125,7 @@ pub fn try_parse_manifest(container_str: &str) -> Result<Container, Box<dyn std:
             ctr
         }
         Err(_) => {
-            log::warn!("Failed to load manifest directly. Will attempt auto-conversion from init-dir format.");
+            log::debug!("Failed to load manifest directly. Will attempt auto-conversion from init-dir format.");
             let manifest = serde_json::from_str(container_str)?;
             let manifest = expand_container_manifest(&manifest)?;
             let internal_state = map_to_internal_state_manifest(manifest)?;


### PR DESCRIPTION
KAD right now loads each manifest, creates the container, waits for the creation to finish and starts the container (again waiting for the container to be brought up) before moving to the next one. This unnecessary since we don't care about start-up order.

This PR makes KAD truly async. Only sync part is the moment where the "/*.json" glob is resolved and then all found manifest are processed asynchronously using a join_all on the generated futures from the deploy() function.

This async behavior is even visible in the logs:
![image](https://github.com/eclipse-leda/leda-utils/assets/59696861/85ef0b8c-1c45-4fa1-aa3c-22f1dca0e12c)

With this modification the initial deployment is much faster as slow-to-deploy containers are not bottle-necking the whole process