### PR TITLE
Github Runners update

### DIFF
--- a/.github/workflows/build-blueprint-selector_dev.yaml
+++ b/.github/workflows/build-blueprint-selector_dev.yaml
@@ -27,9 +27,7 @@ jobs:
           - x86_64-unknown-linux-gnu
         toolchain:
           - stable    
-    # Not using latest here, so that building the binaries uses an older version of glibc
-    # and then can run on newer versions.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-kanto-auto-deployer.yaml
+++ b/.github/workflows/build-kanto-auto-deployer.yaml
@@ -25,10 +25,7 @@ jobs:
         target:
           - aarch64-unknown-linux-gnu
           - x86_64-unknown-linux-gnu
-    
-    # Not using latest here, so that building the binaries uses an older version of glibc
-    # and then can run on newer versions.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -25,10 +25,7 @@ jobs:
         target:
           - aarch64-unknown-linux-gnu
           - x86_64-unknown-linux-gnu
-    
-    # Not using latest here, so that building the binaries uses an older version of glibc
-    # and then can run on newer versions.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-leda-utils.yaml
+++ b/.github/workflows/build-leda-utils.yaml
@@ -24,8 +24,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
-
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
 
   upload-assets:
     name: Upload assets
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: [ call-build ]
     permissions:
       contents: write


### PR DESCRIPTION
ubuntu-20.04 runners are no longer available
Switching to ubuntu-latest for low maintenance