### PR TITLE
Release workflow fixes

### DIFF
--- a/.github/workflows/build-blueprint-selector_dev.yaml
+++ b/.github/workflows/build-blueprint-selector_dev.yaml
@@ -103,7 +103,7 @@ jobs:
           sudo find ./ -maxdepth 1 -name "*.deb" -exec alien --scripts --to-rpm {} \;
       - uses: actions/upload-artifact@v4
         with:
-          name: blueprint-selector-packages
+          name: blueprint-selector-${{ matrix.target }}-packages
           path: |
             ./*.deb
             ./*.rpm

--- a/.github/workflows/build-kanto-auto-deployer.yaml
+++ b/.github/workflows/build-kanto-auto-deployer.yaml
@@ -104,7 +104,7 @@ jobs:
           sudo find ./ -maxdepth 1 -name "*.deb" -exec alien --scripts --to-rpm {} \;
       - uses: actions/upload-artifact@v4
         with:
-          name: kanto-auto-deployer-packages
+          name: kanto-auto-deployer-${{ matrix.target }}-packages
           path: |
             ./*.deb
             ./*.rpm

--- a/.github/workflows/build-kanto-auto-deployer.yaml
+++ b/.github/workflows/build-kanto-auto-deployer.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           workspaces: |
             src/rust/kanto-auto-deployer/ -> target
-            src/rust/kantui/ -> target
+            src/rust/kanto-tui/ -> target
       - name: Build binary
         run: |
           cd src/rust/kanto-auto-deployer

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -107,7 +107,7 @@ jobs:
           sudo find ./ -maxdepth 1 -name "*.deb" -exec alien --scripts --to-rpm {} \;
       - uses: actions/upload-artifact@v4
         with:
-          name: kantui-packages
+          name: kantui-${{ matrix.target }}-packages
           path: |
             ./*.deb
             ./*.rpm

--- a/.github/workflows/build-kantui.yaml
+++ b/.github/workflows/build-kantui.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           workspaces: |
             src/rust/kanto-auto-deployer/ -> target
-            src/rust/kantui/ -> target
+            src/rust/kanto-tui/ -> target
       - name: Build binary
         run: |
           cd src/rust/kanto-tui

--- a/.github/workflows/build-leda-utils.yaml
+++ b/.github/workflows/build-leda-utils.yaml
@@ -92,7 +92,7 @@ jobs:
           sudo find ./ -maxdepth 1 -name "*.deb" -exec alien --scripts --to-rpm {} \;
       - uses: actions/upload-artifact@v4
         with:
-          name: leda-utils-${{ matrix.target }}-packages
+          name: leda-utils-packages
           path: |
             ./*.deb
             ./*.rpm

--- a/.github/workflows/build-leda-utils.yaml
+++ b/.github/workflows/build-leda-utils.yaml
@@ -92,7 +92,7 @@ jobs:
           sudo find ./ -maxdepth 1 -name "*.deb" -exec alien --scripts --to-rpm {} \;
       - uses: actions/upload-artifact@v4
         with:
-          name: leda-utils-packages
+          name: leda-utils-${{ matrix.target }}-packages
           path: |
             ./*.deb
             ./*.rpm

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
         with:
           path: build/
       - name: Upload assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           fail_on_unmatched_files: true
           files: |
@@ -49,5 +49,5 @@ jobs:
             ${{steps.download.outputs.download-path}}/kantui-*-packages/eclipse-leda-kantui*.arm64.rpm
             ${{steps.download.outputs.download-path}}/kanto-auto-deployer-*-packages/eclipse-leda-kanto-auto-deployer*.x86_64.rpm
             ${{steps.download.outputs.download-path}}/kanto-auto-deployer-*-packages/eclipse-leda-kanto-auto-deployer*.arm64.rpm
-            ${{steps.download.outputs.download-path}}/leda-utils-*-packages/eclipse-leda-utils*.noarch.rpm
+            ${{steps.download.outputs.download-path}}/leda-utils-packages/eclipse-leda-utils*.noarch.rpm
             

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Download build artifacts
         id: download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: build/
       - name: Upload assets

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,14 +40,14 @@ jobs:
         with:
           fail_on_unmatched_files: true
           files: |
-            ${{steps.download.outputs.download-path}}/kantui-packages/eclipse-leda-kantui_*_amd64.deb
-            ${{steps.download.outputs.download-path}}/kantui-packages/eclipse-leda-kantui_*_arm64.deb
-            ${{steps.download.outputs.download-path}}/kanto-auto-deployer-packages/eclipse-leda-kanto-auto-deployer_*_amd64.deb
-            ${{steps.download.outputs.download-path}}/kanto-auto-deployer-packages/eclipse-leda-kanto-auto-deployer_*_arm64.deb
-            ${{steps.download.outputs.download-path}}/leda-utils-packages/eclipse-leda-utils*.deb
-            ${{steps.download.outputs.download-path}}/kantui-packages/eclipse-leda-kantui*.x86_64.rpm
-            ${{steps.download.outputs.download-path}}/kantui-packages/eclipse-leda-kantui*.arm64.rpm
-            ${{steps.download.outputs.download-path}}/kanto-auto-deployer-packages/eclipse-leda-kanto-auto-deployer*.x86_64.rpm
-            ${{steps.download.outputs.download-path}}/kanto-auto-deployer-packages/eclipse-leda-kanto-auto-deployer*.arm64.rpm
-            ${{steps.download.outputs.download-path}}/leda-utils-packages/eclipse-leda-utils*.noarch.rpm
+            ${{steps.download.outputs.download-path}}/kantui-*-packages/eclipse-leda-kantui_*_amd64.deb
+            ${{steps.download.outputs.download-path}}/kantui-*-packages/eclipse-leda-kantui_*_arm64.deb
+            ${{steps.download.outputs.download-path}}/kanto-auto-deployer-*-packages/eclipse-leda-kanto-auto-deployer_*_amd64.deb
+            ${{steps.download.outputs.download-path}}/kanto-auto-deployer-*-packages/eclipse-leda-kanto-auto-deployer_*_arm64.deb
+            ${{steps.download.outputs.download-path}}/leda-utils-*-packages/eclipse-leda-utils*.deb
+            ${{steps.download.outputs.download-path}}/kantui-*-packages/eclipse-leda-kantui*.x86_64.rpm
+            ${{steps.download.outputs.download-path}}/kantui-*-packages/eclipse-leda-kantui*.arm64.rpm
+            ${{steps.download.outputs.download-path}}/kanto-auto-deployer-*-packages/eclipse-leda-kanto-auto-deployer*.x86_64.rpm
+            ${{steps.download.outputs.download-path}}/kanto-auto-deployer-*-packages/eclipse-leda-kanto-auto-deployer*.arm64.rpm
+            ${{steps.download.outputs.download-path}}/leda-utils-*-packages/eclipse-leda-utils*.noarch.rpm
             

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,12 +42,12 @@ jobs:
           files: |
             ${{steps.download.outputs.download-path}}/kantui-*-packages/eclipse-leda-kantui_*_amd64.deb
             ${{steps.download.outputs.download-path}}/kantui-*-packages/eclipse-leda-kantui_*_arm64.deb
-            ${{steps.download.outputs.download-path}}/kanto-auto-deployer-*-packages/eclipse-leda-kanto-auto-deployer_*_amd64.deb
-            ${{steps.download.outputs.download-path}}/kanto-auto-deployer-*-packages/eclipse-leda-kanto-auto-deployer_*_arm64.deb
-            ${{steps.download.outputs.download-path}}/leda-utils-*-packages/eclipse-leda-utils*.deb
             ${{steps.download.outputs.download-path}}/kantui-*-packages/eclipse-leda-kantui*.x86_64.rpm
             ${{steps.download.outputs.download-path}}/kantui-*-packages/eclipse-leda-kantui*.arm64.rpm
+            ${{steps.download.outputs.download-path}}/kanto-auto-deployer-*-packages/eclipse-leda-kanto-auto-deployer_*_amd64.deb
+            ${{steps.download.outputs.download-path}}/kanto-auto-deployer-*-packages/eclipse-leda-kanto-auto-deployer_*_arm64.deb
             ${{steps.download.outputs.download-path}}/kanto-auto-deployer-*-packages/eclipse-leda-kanto-auto-deployer*.x86_64.rpm
             ${{steps.download.outputs.download-path}}/kanto-auto-deployer-*-packages/eclipse-leda-kanto-auto-deployer*.arm64.rpm
+            ${{steps.download.outputs.download-path}}/leda-utils-packages/eclipse-leda-utils*.deb
             ${{steps.download.outputs.download-path}}/leda-utils-packages/eclipse-leda-utils*.noarch.rpm
             


### PR DESCRIPTION
Updated to latest version of some GitHub Actions and applied migration steps.

Also updated versions of GitHub Runners from locked ubuntu-20.04 (which is no longer supported) to ubuntu-latest. Downside may be that compiled executables now also required a newer version of glibc and won't run easily on older versions.